### PR TITLE
Call cloud function via web api

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -11,22 +11,6 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   AppGlobalSettings(app);
 
-  // 允许来自web画面的跨域名访问
-  // 根据环境设置 CORS origin
-  const isLocal = process.env.ENVIRONMENT === 'local';
-  const allowedOrigins = isLocal
-    ? true // 本地环境允许所有来源
-    : ['https://www.windy10v10ai.com']; // 生产环境只允许特定域名
-
-  app.enableCors({
-    origin: allowedOrigins,
-    methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Accept', 'Authorization', 'x-api-key'],
-    credentials: true,
-    preflightContinue: false,
-    optionsSuccessStatus: 204,
-  });
-
   if (process.env.ENVIRONMENT == 'local') {
     const config = new DocumentBuilder()
       .setTitle('Windy10v10 Cloud API')

--- a/web/.env
+++ b/web/.env
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_DOMAIN=https://windy10v10ai.web.app/api
+NEXT_PUBLIC_API_DOMAIN=https://api.windy10v10ai.com

--- a/web/.env
+++ b/web/.env
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_DOMAIN=https://api.windy10v10ai.com
+API_DOMAIN=https://api.windy10v10ai.com

--- a/web/app/api/afdian/route.ts
+++ b/web/app/api/afdian/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { afdianActiveUrl } from '@/config/constant';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { steamId, outTradeNo } = body;
+
+    // 调用后端API
+    const response = await fetch(afdianActiveUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        steamId: Number(steamId),
+        outTradeNo,
+      }),
+    });
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error in afdian order active:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/web/app/components/ActiveResult.tsx
+++ b/web/app/components/ActiveResult.tsx
@@ -8,6 +8,7 @@ interface ActiveResultProps {
   activeType: string;
   result: boolean;
   errorMsg?: string;
+  setRequestCommited: (commited: boolean) => void;
 }
 
 const ActiveResult: React.FC<ActiveResultProps> = (props) => {
@@ -32,9 +33,11 @@ const ActiveResult: React.FC<ActiveResultProps> = (props) => {
 
   const handleClick = () => {
     if (props.result) {
+      // 成功时返回首页
       router.push('/');
     } else {
-      router.refresh();
+      // 失败时返回输入页面
+      props.setRequestCommited(false);
     }
   };
 

--- a/web/app/components/ManualActive.tsx
+++ b/web/app/components/ManualActive.tsx
@@ -193,6 +193,7 @@ const ManualActive: React.FC<ManualActiveProps> = (props) => {
             activeType={props.activeType}
             result={activeStatus}
             errorMsg={activeErrmsg}
+            setRequestCommited={setRequestCommited}
           />
         )}
       </div>

--- a/web/app/components/ManualActive.tsx
+++ b/web/app/components/ManualActive.tsx
@@ -4,7 +4,6 @@ import { IdcardOutlined, AccountBookOutlined } from '@ant-design/icons';
 import { Form, Input, Button, Spin } from 'antd';
 import React, { useState } from 'react';
 import { submmitBtnDisableStyle, manualActiveContentStyle } from '../style/CSSProperties';
-import { afdianActiveUrl } from '../../config/constant';
 import axios from 'axios';
 import ActiveResult from './ActiveResult';
 
@@ -66,10 +65,9 @@ const ManualActive: React.FC<ManualActiveProps> = (props) => {
   };
 
   const requestActive = async () => {
-    // await fetchData()
     var requestUrl = '';
     if (props.activeType === 'afdian') {
-      requestUrl = afdianActiveUrl;
+      requestUrl = '/api/afdian';
     }
 
     await axios

--- a/web/config/constant.ts
+++ b/web/config/constant.ts
@@ -1,3 +1,3 @@
-export const API_DOMAIN = process.env.NEXT_PUBLIC_API_DOMAIN;
+export const API_DOMAIN = process.env.API_DOMAIN;
 
 export const afdianActiveUrl = `${API_DOMAIN}/api/afdian/order/active`;

--- a/web/config/constant.ts
+++ b/web/config/constant.ts
@@ -1,3 +1,3 @@
 export const API_DOMAIN = process.env.NEXT_PUBLIC_API_DOMAIN;
 
-export const afdianActiveUrl = `${API_DOMAIN}/afdian/order/active`;
+export const afdianActiveUrl = `${API_DOMAIN}/api/afdian/order/active`;


### PR DESCRIPTION
- fix #513 
- cloud function api 使用了二级域名 api.windy10v10ai.com
  - 但是还是cors domain报错
- Nextjs框架中添加api后段，通过nextjs的API调用cloud function的API

测试环境
https://dev--windy10v10ai.asia-east1.hosted.app/afdian-regist
