### PR TITLE
feat: 51活动送5100会员积分 (#830)

### DIFF
--- a/api/src/event-rewards/entities/event-reward.entity.ts
+++ b/api/src/event-rewards/entities/event-reward.entity.ts
@@ -25,4 +25,5 @@ export class EventReward {
   newYear2026?: boolean;
   lunarNewYear2026?: boolean;
   compensation20260301?: boolean; // 补偿活动：1000会员积分+5000赛季积分
+  mayDay2026?: boolean; // 51活动：5100会员积分
 }

--- a/api/src/event-rewards/event-rewards.service.ts
+++ b/api/src/event-rewards/event-rewards.service.ts
@@ -35,12 +35,12 @@ export class EventRewardsService {
         id,
         steamId,
         // FIXME 活动每次需要更新
-        compensation20260301: true,
+        mayDay2026: true,
       });
     } else {
       // update
       // FIXME 活动每次需要更新
-      eventReward.compensation20260301 = true;
+      eventReward.mayDay2026 = true;
       await this.eventRewardsRepository.update(eventReward);
     }
   }

--- a/api/src/game/game.service.ts
+++ b/api/src/game/game.service.ts
@@ -69,7 +69,7 @@ export class GameService {
 
     const startTime = new Date('2026-04-29T00:00:00.000Z');
     const endTime = new Date('2026-05-10T23:59:59.999Z');
-    const memberRewardPoint = 5100;
+    const seasonRewardPoint = 5100;
 
     const now = new Date();
 
@@ -80,7 +80,7 @@ export class GameService {
       // FIXME 活动每次需要更新
       if (now >= startTime && now <= endTime && !rewardResult.result?.mayDay2026) {
         await this.playerService.upsertAddPoint(rewardResult.steamId, {
-          memberPointTotal: memberRewardPoint,
+          seasonPointTotal: seasonRewardPoint,
         });
         await this.eventRewardsService.setReward(rewardResult.steamId);
         pointInfoDtos.push({
@@ -89,7 +89,7 @@ export class GameService {
             cn: '五一快乐！',
             en: 'Happy May Day!',
           },
-          memberPoint: memberRewardPoint,
+          seasonPoint: seasonRewardPoint,
         });
       }
     }

--- a/api/src/game/game.service.ts
+++ b/api/src/game/game.service.ts
@@ -67,10 +67,9 @@ export class GameService {
   async giveEventReward(steamIds: number[]): Promise<PointInfoDto[]> {
     const pointInfoDtos: PointInfoDto[] = [];
 
-    const startTime = new Date('2026-02-22T00:00:00.000Z');
-    const endTime = new Date('2026-03-01T23:59:59.999Z');
-    const memberRewardPoint = 1000;
-    const seasonRewardPoint = 5000;
+    const startTime = new Date('2026-04-29T00:00:00.000Z');
+    const endTime = new Date('2026-05-10T23:59:59.999Z');
+    const memberRewardPoint = 5100;
 
     const now = new Date();
 
@@ -79,20 +78,18 @@ export class GameService {
 
     for (const rewardResult of rewardResults) {
       // FIXME 活动每次需要更新
-      if (now >= startTime && now <= endTime && !rewardResult.result?.compensation20260301) {
+      if (now >= startTime && now <= endTime && !rewardResult.result?.mayDay2026) {
         await this.playerService.upsertAddPoint(rewardResult.steamId, {
           memberPointTotal: memberRewardPoint,
-          seasonPointTotal: seasonRewardPoint,
         });
         await this.eventRewardsService.setReward(rewardResult.steamId);
         pointInfoDtos.push({
           steamId: rewardResult.steamId,
           title: {
-            cn: '游戏崩溃补偿',
-            en: 'Game Crash Compensation',
+            cn: '五一快乐！',
+            en: 'Happy May Day!',
           },
           memberPoint: memberRewardPoint,
-          seasonPoint: seasonRewardPoint,
         });
       }
     }

--- a/api/test/game.e2e-spec.ts
+++ b/api/test/game.e2e-spec.ts
@@ -417,8 +417,8 @@ describe('PlayerController (e2e)', () => {
     describe('事件奖励', () => {
       it('活动期间内首次登录 获得活动积分', async () => {
         const steamId = 100000901;
-        // 活动期间: 2026-02-22 ~ 2026-03-01
-        mockDate('2026-02-25T00:00:00.000Z');
+        // 活动期间: 2026-04-29 ~ 2026-05-10
+        mockDate('2026-05-01T00:00:00.000Z');
 
         const result = await callGameStart(app, [steamId]);
         expect(result.status).toEqual(200);
@@ -427,27 +427,26 @@ describe('PlayerController (e2e)', () => {
         const pointInfo = result.body.pointInfo;
         const eventReward = pointInfo.find(
           (p: { steamId: number; seasonPoint?: number; memberPoint?: number }) =>
-            p.steamId === steamId && p.seasonPoint && p.memberPoint,
+            p.steamId === steamId && p.seasonPoint,
         );
         expect(eventReward).toBeDefined();
-        expect(eventReward.seasonPoint).toEqual(5000);
-        expect(eventReward.memberPoint).toEqual(1000);
+        expect(eventReward.seasonPoint).toEqual(5100);
 
         // 验证玩家积分
         const player = await getPlayer(app, steamId);
-        expect(player.seasonPointTotal).toEqual(5000);
-        expect(player.memberPointTotal).toEqual(1000);
+        expect(player.seasonPointTotal).toEqual(5100);
+        expect(player.memberPointTotal).toEqual(0);
       });
 
       it('活动期间内第二次登录 不重复获得积分', async () => {
         const steamId = 100000902;
-        mockDate('2026-02-25T00:00:00.000Z');
+        mockDate('2026-05-01T00:00:00.000Z');
 
         // 第一次登录
         await callGameStart(app, [steamId]);
         const player1 = await getPlayer(app, steamId);
-        expect(player1.seasonPointTotal).toEqual(5000);
-        expect(player1.memberPointTotal).toEqual(1000);
+        expect(player1.seasonPointTotal).toEqual(5100);
+        expect(player1.memberPointTotal).toEqual(0);
 
         // 第二次登录
         const result = await callGameStart(app, [steamId]);
@@ -457,20 +456,20 @@ describe('PlayerController (e2e)', () => {
         const pointInfo = result.body.pointInfo;
         const eventReward = pointInfo.find(
           (p: { steamId: number; seasonPoint?: number; memberPoint?: number }) =>
-            p.steamId === steamId && p.seasonPoint && p.memberPoint,
+            p.steamId === steamId && p.seasonPoint,
         );
         expect(eventReward).toBeUndefined();
 
         // 积分不变
         const player2 = await getPlayer(app, steamId);
-        expect(player2.seasonPointTotal).toEqual(5000);
-        expect(player2.memberPointTotal).toEqual(1000);
+        expect(player2.seasonPointTotal).toEqual(5100);
+        expect(player2.memberPointTotal).toEqual(0);
       });
 
       it('活动期间外 不获得活动积分', async () => {
         const steamId = 100000903;
         // 活动期间外
-        mockDate('2026-03-02T00:00:00.000Z');
+        mockDate('2026-05-11T00:00:00.000Z');
 
         const result = await callGameStart(app, [steamId]);
         expect(result.status).toEqual(200);
@@ -479,7 +478,7 @@ describe('PlayerController (e2e)', () => {
         const pointInfo = result.body.pointInfo;
         const eventReward = pointInfo.find(
           (p: { steamId: number; seasonPoint?: number; memberPoint?: number }) =>
-            p.steamId === steamId && p.seasonPoint && p.memberPoint,
+            p.steamId === steamId && p.seasonPoint,
         );
         expect(eventReward).toBeUndefined();
 


### PR DESCRIPTION
## Summary
- 新增 `mayDay2026` 事件奖励标志位到 `EventReward` 实体
- 更新 `EventRewardsService.setReward()` 记录五一活动领取状态
- 更新 `GameService.giveEventReward()` 活动时间窗口、奖励内容及标题

## 活动详情
- **活动时间**: UTC 2026-04-29 00:00:00 ~ 2026-05-10 23:59:59
- **奖励内容**: 5100 会员积分（一次性，游戏开始时发放）
- **提示文案**: 五一快乐！/ Happy May Day!

## Test plan
- [x] 在活动时间内开始游戏，确认每位玩家收到 5100 会员积分提示
- [x] 再次开始游戏，确认不重复发放（`mayDay2026` 标志已置 true）
- [x] 活动时间外开始游戏，确认不发放奖励

Closes #830