### PR TITLE
[Alipay] Step 3: 查询接口 + Webhook 验签 + 奖励发放

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,21 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "git.autofetch": true,
   "debug.javascript.autoAttachFilter": "smart",
+  "debug.javascript.autoAttachSmartPattern": [
+    "${workspaceFolder}/**",
+    "!**/node_modules/**",
+    "**/$KNOWN_TOOLS$",
+    "**/firebase-tools/**",
+    "**/.bin/firebase"
+  ],
+  "debug.javascript.terminalOptions": {
+    "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+    "outFiles": [
+      "${workspaceFolder}/api/dist/**/*.js",
+      "${workspaceFolder}/api/**/*.js"
+    ],
+    "sourceMaps": true
+  },
   "typescript.preferences.importModuleSpecifier": "relative",
   "githubPullRequests.ignoredPullRequestBranches": ["develop"],
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],

--- a/api/.env.local
+++ b/api/.env.local
@@ -12,6 +12,7 @@ GA_MEASUREMENT_ID=G-CKJ09PRKP9
 GA4_API_SECRET=Vm-EA2HyS8W4S102NBe43Q
 
 ALIPAY_ENV=sandbox
+ALIPAY_NOTIFY_URL=https://xxx.ngrok-free.dev/api/alipay/webhook
 ALIPAY_APP_ID=replace-me-sandbox-app-id
 ALIPAY_APP_PRIVATE_KEY=replace-me-pkcs8-private-key
 ALIPAY_PUBLIC_KEY=replace-me-alipay-public-key

--- a/api/.env.windy10v10ai
+++ b/api/.env.windy10v10ai
@@ -13,6 +13,7 @@ GA_MEASUREMENT_ID=G-X4ER7HG60N
 # GA4_API_SECRET=use-secret-value
 
 ALIPAY_ENV=prod
+ALIPAY_NOTIFY_URL=https://windy10v10ai.com/api/alipay/webhook
 # ALIPAY_APP_ID=use-secret-value
 # ALIPAY_APP_PRIVATE_KEY=use-secret-value
 # ALIPAY_PUBLIC_KEY=use-secret-value

--- a/api/src/alipay/alipay.api.service.ts
+++ b/api/src/alipay/alipay.api.service.ts
@@ -67,4 +67,13 @@ export class AlipayApiService {
     }
     return result.qrCode;
   }
+
+  /**
+   * 验签支付宝异步通知。
+   * 入参为通知请求 body 的所有字段（含 sign / sign_type）。
+   * SDK 内部会自动剔除 sign 字段后用 alipayPublicKey 校验签名。
+   */
+  verifyNotifySign(postData: Record<string, string | undefined>): boolean {
+    return this.getSdk().checkNotifySignV2(postData);
+  }
 }

--- a/api/src/alipay/alipay.api.service.ts
+++ b/api/src/alipay/alipay.api.service.ts
@@ -50,8 +50,9 @@ export class AlipayApiService {
 
   async precreate(outTradeNo: string, totalAmount: string, subject: string): Promise<string> {
     const sdk = this.getSdk();
-    // notify_url 在支付宝开放平台应用网关里配置，不在 precreate 参数里传
+    const notifyUrl = process.env.ALIPAY_NOTIFY_URL;
     const result = (await sdk.exec('alipay.trade.precreate', {
+      notify_url: notifyUrl,
       bizContent: {
         out_trade_no: outTradeNo,
         total_amount: totalAmount,

--- a/api/src/alipay/alipay.api.service.ts
+++ b/api/src/alipay/alipay.api.service.ts
@@ -74,6 +74,14 @@ export class AlipayApiService {
    * SDK 内部会自动剔除 sign 字段后用 alipayPublicKey 校验签名。
    */
   verifyNotifySign(postData: Record<string, string | undefined>): boolean {
-    return this.getSdk().checkNotifySignV2(postData);
+    try {
+      return this.getSdk().checkNotifySignV2(postData);
+    } catch (err) {
+      // 抛异常当作验签失败处理，避免伪造请求把 webhook 端点打成 500。
+      logger.warn('[Alipay] verifyNotifySign 抛异常，按验签失败处理', {
+        error: (err as Error).message,
+      });
+      return false;
+    }
   }
 }

--- a/api/src/alipay/alipay.constants.ts
+++ b/api/src/alipay/alipay.constants.ts
@@ -16,22 +16,22 @@ export interface AlipayProductSpec {
 
 export const ALIPAY_PRODUCT_TABLE: Record<AlipayProductCode, AlipayProductSpec> = {
   [AlipayProductCode.MEMBER_PREMIUM]: {
-    subjectUnit: '高级会员',
+    subjectUnit: '10v10AI 高级会员',
     priceCentPerUnit: 2800,
     reward: { kind: 'member', level: MemberLevel.PREMIUM },
   },
   [AlipayProductCode.POINTS_TIER1]: {
-    subjectUnit: '会员积分 3500',
+    subjectUnit: '10v10AI 会员积分 3500',
     priceCentPerUnit: 7800,
     reward: { kind: 'points', points: 3500 },
   },
   [AlipayProductCode.POINTS_TIER2]: {
-    subjectUnit: '会员积分 11000',
+    subjectUnit: '10v10AI 会员积分 11000',
     priceCentPerUnit: 23800,
     reward: { kind: 'points', points: 11000 },
   },
   [AlipayProductCode.POINTS_TIER3]: {
-    subjectUnit: '会员积分 28000',
+    subjectUnit: '10v10AI 会员积分 28000',
     priceCentPerUnit: 56800,
     reward: { kind: 'points', points: 28000 },
   },

--- a/api/src/alipay/alipay.controller.ts
+++ b/api/src/alipay/alipay.controller.ts
@@ -42,6 +42,7 @@ export class AlipayController {
     logger.info('Alipay webhook received', {
       outTradeNo: body?.out_trade_no,
       tradeStatus: body?.trade_status,
+      alipayTradeNo: body?.trade_no,
     });
     return this.alipayService.handleWebhook(body);
   }

--- a/api/src/alipay/alipay.controller.ts
+++ b/api/src/alipay/alipay.controller.ts
@@ -1,12 +1,15 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Header, Post, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { logger } from 'firebase-functions/v2';
 
 import { Public } from '../util/auth/public.decorator';
 
 import { AlipayService } from './alipay.service';
+import { AlipayNotifyDto } from './dto/alipay-notify.dto';
 import { CreateAlipayOrderResponseDto } from './dto/create-alipay-order-response.dto';
 import { CreateAlipayOrderDto } from './dto/create-alipay-order.dto';
+import { QueryAlipayOrderResponseDto } from './dto/query-alipay-order-response.dto';
+import { QueryAlipayOrderDto } from './dto/query-alipay-order.dto';
 
 @ApiTags('Alipay')
 @Controller('alipay')
@@ -19,9 +22,27 @@ export class AlipayController {
     return this.alipayService.createOrder(dto);
   }
 
+  @Get('/order/query')
+  async queryOrder(@Query() dto: QueryAlipayOrderDto): Promise<QueryAlipayOrderResponseDto> {
+    return this.alipayService.getOrderStatus(dto.outTradeNo);
+  }
+
+  /**
+   * 支付宝异步通知端点，application/x-www-form-urlencoded。
+   *
+   * Firebase Cloud Functions 已将 form-urlencoded body 自动解析为 req.body 对象，
+   * 所以这里直接 @Body() 拿到字段集合即可，无需额外挂 express.urlencoded 中间件。
+   *
+   * 必须按支付宝规范回纯文本 'success' / 'failure'，不能带 JSON 包装。
+   */
   @Public()
   @Post('/webhook')
-  async webhook() {
-    // Step 4 实现
+  @Header('Content-Type', 'text/plain')
+  async webhook(@Body() body: AlipayNotifyDto): Promise<string> {
+    logger.info('Alipay webhook received', {
+      outTradeNo: body?.out_trade_no,
+      tradeStatus: body?.trade_status,
+    });
+    return this.alipayService.handleWebhook(body);
   }
 }

--- a/api/src/alipay/alipay.module.ts
+++ b/api/src/alipay/alipay.module.ts
@@ -1,6 +1,9 @@
 import { Module } from '@nestjs/common';
 import { FireormModule } from 'nestjs-fireorm';
 
+import { AnalyticsModule } from '../analytics/analytics.module';
+import { MembersModule } from '../members/members.module';
+import { PlayerModule } from '../player/player.module';
 import { SecretModule } from '../util/secret/secret.module';
 
 import { AlipayApiService } from './alipay.api.service';
@@ -9,7 +12,13 @@ import { AlipayService } from './alipay.service';
 import { AlipayOrder } from './entities/alipay-order.entity';
 
 @Module({
-  imports: [FireormModule.forFeature([AlipayOrder]), SecretModule],
+  imports: [
+    FireormModule.forFeature([AlipayOrder]),
+    SecretModule,
+    MembersModule,
+    PlayerModule,
+    AnalyticsModule,
+  ],
   controllers: [AlipayController],
   providers: [AlipayService, AlipayApiService],
   exports: [AlipayService, AlipayApiService],

--- a/api/src/alipay/alipay.service.spec.ts
+++ b/api/src/alipay/alipay.service.spec.ts
@@ -1,6 +1,11 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from 'nestjs-fireorm';
+
+import { AnalyticsPurchaseService } from '../analytics/analytics.purchase.service';
+import { MemberLevel } from '../members/entities/members.entity';
+import { MembersService } from '../members/members.service';
+import { PlayerService } from '../player/player.service';
 
 import { AlipayApiService } from './alipay.api.service';
 import { ALIPAY_PRODUCT_TABLE, ALIPAY_QR_EXPIRE_MS } from './alipay.constants';
@@ -13,12 +18,20 @@ import { AlipayTradeStatus } from './enums/alipay-trade-status.enum';
 describe('AlipayService', () => {
   let service: AlipayService;
   let apiService: jest.Mocked<AlipayApiService>;
-  let repo: { create: jest.Mock; update: jest.Mock };
+  let repo: {
+    create: jest.Mock;
+    update: jest.Mock;
+    findById: jest.Mock;
+  };
+  let membersService: jest.Mocked<MembersService>;
+  let playerService: jest.Mocked<PlayerService>;
+  let analyticsPurchaseService: jest.Mocked<AnalyticsPurchaseService>;
 
   beforeEach(async () => {
     repo = {
       create: jest.fn().mockImplementation((entity) => Promise.resolve({ ...entity })),
       update: jest.fn().mockImplementation((entity) => Promise.resolve(entity)),
+      findById: jest.fn(),
     };
 
     const moduleRef = await Test.createTestingModule({
@@ -26,17 +39,35 @@ describe('AlipayService', () => {
         AlipayService,
         {
           provide: AlipayApiService,
-          useValue: { precreate: jest.fn().mockResolvedValue('https://qr.alipay.com/mock') },
+          useValue: {
+            precreate: jest.fn().mockResolvedValue('https://qr.alipay.com/mock'),
+            verifyNotifySign: jest.fn().mockReturnValue(true),
+          },
         },
         {
           provide: getRepositoryToken(AlipayOrder),
           useValue: repo,
+        },
+        {
+          provide: MembersService,
+          useValue: { createMember: jest.fn().mockResolvedValue({}) },
+        },
+        {
+          provide: PlayerService,
+          useValue: { upsertAddPoint: jest.fn().mockResolvedValue({}) },
+        },
+        {
+          provide: AnalyticsPurchaseService,
+          useValue: { alipayPurchase: jest.fn().mockResolvedValue(undefined) },
         },
       ],
     }).compile();
 
     service = moduleRef.get<AlipayService>(AlipayService);
     apiService = moduleRef.get(AlipayApiService);
+    membersService = moduleRef.get(MembersService);
+    playerService = moduleRef.get(PlayerService);
+    analyticsPurchaseService = moduleRef.get(AnalyticsPurchaseService);
   });
 
   describe('calculatePrice', () => {
@@ -195,6 +226,228 @@ describe('AlipayService', () => {
 
       expect(expiresMs).toBeGreaterThanOrEqual(before + ALIPAY_QR_EXPIRE_MS);
       expect(expiresMs).toBeLessThanOrEqual(after + ALIPAY_QR_EXPIRE_MS);
+    });
+  });
+
+  describe('getOrderStatus', () => {
+    it('返回 outTradeNo 和 status', async () => {
+      repo.findById.mockResolvedValueOnce({
+        outTradeNo: 'ali-1-2-x',
+        status: AlipayTradeStatus.WAITING,
+      });
+      const res = await service.getOrderStatus('ali-1-2-x');
+      expect(res).toEqual({ outTradeNo: 'ali-1-2-x', status: AlipayTradeStatus.WAITING });
+    });
+
+    it('订单不存在抛 NotFoundException', async () => {
+      repo.findById.mockResolvedValueOnce(undefined);
+      await expect(service.getOrderStatus('missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('handleWebhook', () => {
+    const buildOrder = (overrides: Partial<AlipayOrder> = {}): AlipayOrder =>
+      ({
+        id: 'ali-123-1-x',
+        outTradeNo: 'ali-123-1-x',
+        steamId: 123,
+        productCode: AlipayProductCode.MEMBER_PREMIUM,
+        quantity: 1,
+        totalAmountCent: 2800,
+        subject: '高级会员',
+        status: AlipayTradeStatus.WAITING,
+        qrCode: 'https://qr.alipay.com/mock',
+        qrCodeExpiresAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ...overrides,
+      }) as AlipayOrder;
+
+    const buildNotify = (overrides: Record<string, string> = {}): Record<string, string> => ({
+      out_trade_no: 'ali-123-1-x',
+      trade_status: 'TRADE_SUCCESS',
+      total_amount: '28.00',
+      trade_no: '2026050322001400000000001',
+      buyer_id: '2088000000000001',
+      buyer_logon_id: 'sandbox***@example.com',
+      gmt_payment: '2026-05-03 20:00:00',
+      sign: 'mock-sign',
+      sign_type: 'RSA2',
+      ...overrides,
+    });
+
+    it('验签失败：返回 failure，不读 Firestore，不发奖', async () => {
+      apiService.verifyNotifySign.mockReturnValueOnce(false);
+
+      const result = await service.handleWebhook(buildNotify());
+
+      expect(result).toBe('failure');
+      expect(repo.findById).not.toHaveBeenCalled();
+      expect(repo.update).not.toHaveBeenCalled();
+      expect(membersService.createMember).not.toHaveBeenCalled();
+      expect(playerService.upsertAddPoint).not.toHaveBeenCalled();
+      expect(analyticsPurchaseService.alipayPurchase).not.toHaveBeenCalled();
+    });
+
+    it('订单不存在：返回 failure', async () => {
+      repo.findById.mockResolvedValueOnce(undefined);
+      const result = await service.handleWebhook(buildNotify());
+      expect(result).toBe('failure');
+      expect(repo.update).not.toHaveBeenCalled();
+    });
+
+    it('幂等：订单已 SUCCESS，返回 success 但不重复发奖', async () => {
+      repo.findById.mockResolvedValueOnce(buildOrder({ status: AlipayTradeStatus.SUCCESS }));
+
+      const result = await service.handleWebhook(buildNotify());
+
+      expect(result).toBe('success');
+      expect(membersService.createMember).not.toHaveBeenCalled();
+      expect(playerService.upsertAddPoint).not.toHaveBeenCalled();
+      expect(analyticsPurchaseService.alipayPurchase).not.toHaveBeenCalled();
+      expect(repo.update).not.toHaveBeenCalled();
+    });
+
+    it('trade_status 非 TRADE_SUCCESS/TRADE_FINISHED：返回 failure', async () => {
+      repo.findById.mockResolvedValueOnce(buildOrder());
+
+      const result = await service.handleWebhook(buildNotify({ trade_status: 'WAIT_BUYER_PAY' }));
+
+      expect(result).toBe('failure');
+      expect(membersService.createMember).not.toHaveBeenCalled();
+    });
+
+    it('金额不匹配：返回 failure，不发奖', async () => {
+      repo.findById.mockResolvedValueOnce(buildOrder({ totalAmountCent: 2800 }));
+
+      const result = await service.handleWebhook(buildNotify({ total_amount: '0.01' }));
+
+      expect(result).toBe('failure');
+      expect(membersService.createMember).not.toHaveBeenCalled();
+      expect(playerService.upsertAddPoint).not.toHaveBeenCalled();
+      expect(repo.update).not.toHaveBeenCalled();
+    });
+
+    it('缺 out_trade_no：返回 failure', async () => {
+      const notify = buildNotify();
+      delete notify.out_trade_no;
+      const result = await service.handleWebhook(notify);
+      expect(result).toBe('failure');
+      expect(repo.findById).not.toHaveBeenCalled();
+    });
+
+    it('会员订单 quantity=1：调 MembersService.createMember(month=1, level=PREMIUM)', async () => {
+      const order = buildOrder({ productCode: AlipayProductCode.MEMBER_PREMIUM, quantity: 1 });
+      repo.findById.mockResolvedValueOnce(order);
+
+      const result = await service.handleWebhook(buildNotify());
+
+      expect(result).toBe('success');
+      expect(membersService.createMember).toHaveBeenCalledWith({
+        steamId: 123,
+        month: 1,
+        level: MemberLevel.PREMIUM,
+      });
+      expect(playerService.upsertAddPoint).not.toHaveBeenCalled();
+    });
+
+    it('会员订单 quantity=3：month 取 quantity 值', async () => {
+      const order = buildOrder({
+        productCode: AlipayProductCode.MEMBER_PREMIUM,
+        quantity: 3,
+        totalAmountCent: 8400,
+      });
+      repo.findById.mockResolvedValueOnce(order);
+
+      await service.handleWebhook(buildNotify({ total_amount: '84.00' }));
+
+      expect(membersService.createMember).toHaveBeenCalledWith({
+        steamId: 123,
+        month: 3,
+        level: MemberLevel.PREMIUM,
+      });
+    });
+
+    it('积分订单：调 upsertAddPoint(reward.points * quantity)', async () => {
+      const order = buildOrder({
+        productCode: AlipayProductCode.POINTS_TIER1,
+        quantity: 2,
+        totalAmountCent: 15600,
+      });
+      repo.findById.mockResolvedValueOnce(order);
+
+      await service.handleWebhook(buildNotify({ total_amount: '156.00' }));
+
+      expect(playerService.upsertAddPoint).toHaveBeenCalledWith(123, {
+        memberPointTotal: 7000, // 3500 * 2
+      });
+      expect(membersService.createMember).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      [AlipayProductCode.POINTS_TIER1, 1, 7800, '78.00', 3500],
+      [AlipayProductCode.POINTS_TIER2, 1, 23800, '238.00', 11000],
+      [AlipayProductCode.POINTS_TIER3, 1, 56800, '568.00', 28000],
+    ])(
+      '积分档位 %s 单份发放正确积分',
+      async (code, quantity, totalAmountCent, amountStr, points) => {
+        const order = buildOrder({ productCode: code, quantity, totalAmountCent });
+        repo.findById.mockResolvedValueOnce(order);
+
+        await service.handleWebhook(buildNotify({ total_amount: amountStr }));
+
+        expect(playerService.upsertAddPoint).toHaveBeenCalledWith(
+          123,
+          expect.objectContaining({ memberPointTotal: points }),
+        );
+      },
+    );
+
+    it('成功后写订单 SUCCESS + alipayTradeNo + buyer 信息 + rawNotify', async () => {
+      const order = buildOrder();
+      repo.findById.mockResolvedValueOnce(order);
+
+      await service.handleWebhook(buildNotify());
+
+      expect(repo.update).toHaveBeenCalledTimes(1);
+      const updated = repo.update.mock.calls[0][0];
+      expect(updated.status).toBe(AlipayTradeStatus.SUCCESS);
+      expect(updated.alipayTradeNo).toBe('2026050322001400000000001');
+      expect(updated.buyerUserId).toBe('2088000000000001');
+      expect(updated.buyerLogonId).toBe('sandbox***@example.com');
+      expect(updated.rawNotify).toMatchObject({ trade_status: 'TRADE_SUCCESS' });
+    });
+
+    it('成功后发 GA4 alipayPurchase 事件', async () => {
+      const order = buildOrder();
+      repo.findById.mockResolvedValueOnce(order);
+
+      await service.handleWebhook(buildNotify());
+
+      expect(analyticsPurchaseService.alipayPurchase).toHaveBeenCalledTimes(1);
+      const ev = analyticsPurchaseService.alipayPurchase.mock.calls[0][0];
+      expect(ev.status).toBe(AlipayTradeStatus.SUCCESS);
+      expect(ev.outTradeNo).toBe('ali-123-1-x');
+    });
+
+    it('TRADE_FINISHED 也按成功处理（部分商户场景）', async () => {
+      const order = buildOrder();
+      repo.findById.mockResolvedValueOnce(order);
+
+      const result = await service.handleWebhook(buildNotify({ trade_status: 'TRADE_FINISHED' }));
+
+      expect(result).toBe('success');
+      expect(membersService.createMember).toHaveBeenCalled();
+    });
+
+    it('安全顺序：验签 必须早于 任何 Firestore 读写', async () => {
+      apiService.verifyNotifySign.mockReturnValueOnce(false);
+
+      await service.handleWebhook(buildNotify());
+
+      expect(apiService.verifyNotifySign).toHaveBeenCalled();
+      expect(repo.findById).not.toHaveBeenCalled();
+      expect(repo.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/api/src/alipay/alipay.service.ts
+++ b/api/src/alipay/alipay.service.ts
@@ -149,7 +149,7 @@ export class AlipayService {
     order.alipayTradeNo = notify.trade_no;
     order.buyerUserId = notify.buyer_id;
     order.buyerLogonId = notify.buyer_logon_id;
-    order.gmtPayment = notify.gmt_payment ? new Date(notify.gmt_payment) : undefined;
+    order.gmtPayment = this.parseAlipayDateTime(notify.gmt_payment);
     order.rawNotify = { ...notify };
     order.updatedAt = new Date();
     await this.alipayOrderRepository.update(order);
@@ -233,5 +233,18 @@ export class AlipayService {
     const ts = Date.now();
     const rand = Math.random().toString(36).slice(2, 6);
     return `ali-${steamId}-${ts}-${rand}`;
+  }
+
+  /**
+   * 支付宝下行的 gmt_payment 是「YYYY-MM-DD HH:mm:ss」北京时间字符串。
+   * Cloud Functions 默认 UTC 时区，直接 new Date(str) 会被当成 UTC，导致存储时间晚 8 小时。
+   * 显式拼上 +08:00 偏移再解析，确保 Date 对象指向真实 UTC 时刻。
+   */
+  private parseAlipayDateTime(value: string | undefined): Date | undefined {
+    if (!value) {
+      return undefined;
+    }
+    const date = new Date(`${value.replace(' ', 'T')}+08:00`);
+    return Number.isNaN(date.getTime()) ? undefined : date;
   }
 }

--- a/api/src/alipay/alipay.service.ts
+++ b/api/src/alipay/alipay.service.ts
@@ -176,9 +176,25 @@ export class AlipayService {
         month: order.quantity,
         level: reward.level,
       });
+      logger.info('[Alipay] 奖励发放成功 - 会员', {
+        outTradeNo: order.outTradeNo,
+        steamId: order.steamId,
+        productCode: order.productCode,
+        quantity: order.quantity,
+        level: reward.level,
+        month: order.quantity,
+      });
     } else {
+      const points = reward.points * order.quantity;
       await this.playerService.upsertAddPoint(order.steamId, {
-        memberPointTotal: reward.points * order.quantity,
+        memberPointTotal: points,
+      });
+      logger.info('[Alipay] 奖励发放成功 - 积分', {
+        outTradeNo: order.outTradeNo,
+        steamId: order.steamId,
+        productCode: order.productCode,
+        quantity: order.quantity,
+        points,
       });
     }
   }

--- a/api/src/alipay/alipay.service.ts
+++ b/api/src/alipay/alipay.service.ts
@@ -1,13 +1,25 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { logger } from 'firebase-functions/v2';
 import { BaseFirestoreRepository } from 'fireorm';
 import { InjectRepository } from 'nestjs-fireorm';
 
+import { AnalyticsPurchaseService } from '../analytics/analytics.purchase.service';
+import { MembersService } from '../members/members.service';
+import { PlayerService } from '../player/player.service';
+
 import { AlipayApiService } from './alipay.api.service';
 import { ALIPAY_PRODUCT_TABLE, ALIPAY_QR_EXPIRE_MS, AlipayProductSpec } from './alipay.constants';
+import { AlipayNotifyDto } from './dto/alipay-notify.dto';
 import { CreateAlipayOrderResponseDto } from './dto/create-alipay-order-response.dto';
 import { CreateAlipayOrderDto } from './dto/create-alipay-order.dto';
+import { QueryAlipayOrderResponseDto } from './dto/query-alipay-order-response.dto';
 import { AlipayOrder } from './entities/alipay-order.entity';
 import { AlipayTradeStatus } from './enums/alipay-trade-status.enum';
+
+const ALIPAY_TRADE_SUCCESS = 'TRADE_SUCCESS';
+const ALIPAY_TRADE_FINISHED = 'TRADE_FINISHED';
+const WEBHOOK_RESPONSE_SUCCESS = 'success';
+const WEBHOOK_RESPONSE_FAILURE = 'failure';
 
 @Injectable()
 export class AlipayService {
@@ -15,6 +27,9 @@ export class AlipayService {
     private readonly alipayApiService: AlipayApiService,
     @InjectRepository(AlipayOrder)
     private readonly alipayOrderRepository: BaseFirestoreRepository<AlipayOrder>,
+    private readonly membersService: MembersService,
+    private readonly playerService: PlayerService,
+    private readonly analyticsPurchaseService: AnalyticsPurchaseService,
   ) {}
 
   async createOrder(dto: CreateAlipayOrderDto): Promise<CreateAlipayOrderResponseDto> {
@@ -60,6 +75,112 @@ export class AlipayService {
       subject,
       expiresAt: expiresAt.toISOString(),
     };
+  }
+
+  async getOrderStatus(outTradeNo: string): Promise<QueryAlipayOrderResponseDto> {
+    const order = await this.alipayOrderRepository.findById(outTradeNo);
+    if (!order) {
+      throw new NotFoundException(`Alipay order not found: ${outTradeNo}`);
+    }
+    return { outTradeNo: order.outTradeNo, status: order.status };
+  }
+
+  /**
+   * 处理支付宝异步通知。返回值为给支付宝的纯文本响应（'success' / 'failure'）。
+   *
+   * 安全顺序硬性要求：
+   *   1. 验签必须在任何 Firestore 读写、任何对 trade_status / total_amount /
+   *      buyer_* 字段的信任使用之前完成。
+   *   2. 验签失败立即返回 'failure'，不做任何状态变更。
+   *
+   * 业务流程：
+   *   验签 → 必填字段 → 查订单 → 幂等命中（SUCCESS）即返回 → 校验
+   *   trade_status / 金额 → 应用奖励 → 写订单 SUCCESS → GA4 事件 → 'success'
+   */
+  async handleWebhook(notify: AlipayNotifyDto): Promise<string> {
+    if (!this.alipayApiService.verifyNotifySign(notify)) {
+      logger.warn('[Alipay] Webhook 验签失败', { outTradeNo: notify.out_trade_no });
+      return WEBHOOK_RESPONSE_FAILURE;
+    }
+
+    const outTradeNo = notify.out_trade_no;
+    const tradeStatus = notify.trade_status;
+    const totalAmountStr = notify.total_amount;
+    if (!outTradeNo || !tradeStatus || !totalAmountStr) {
+      logger.warn('[Alipay] Webhook 缺少必填字段', {
+        outTradeNo,
+        tradeStatus,
+        totalAmount: totalAmountStr,
+      });
+      return WEBHOOK_RESPONSE_FAILURE;
+    }
+
+    const order = await this.alipayOrderRepository.findById(outTradeNo);
+    if (!order) {
+      logger.warn('[Alipay] Webhook 订单不存在', { outTradeNo });
+      return WEBHOOK_RESPONSE_FAILURE;
+    }
+
+    // 幂等：已 SUCCESS 直接回 success，不重复发奖
+    if (order.status === AlipayTradeStatus.SUCCESS) {
+      logger.info('[Alipay] Webhook 重复通知，订单已 SUCCESS', { outTradeNo });
+      return WEBHOOK_RESPONSE_SUCCESS;
+    }
+
+    if (tradeStatus !== ALIPAY_TRADE_SUCCESS && tradeStatus !== ALIPAY_TRADE_FINISHED) {
+      logger.warn('[Alipay] Webhook trade_status 非成功', { outTradeNo, tradeStatus });
+      return WEBHOOK_RESPONSE_FAILURE;
+    }
+
+    // total_amount 单位「元」，订单存的是分；按分比对避免浮点误差
+    const notifyAmountCent = Math.round(Number(totalAmountStr) * 100);
+    if (!Number.isFinite(notifyAmountCent) || notifyAmountCent !== order.totalAmountCent) {
+      logger.error('[Alipay] Webhook 金额不匹配', {
+        outTradeNo,
+        notifyAmount: totalAmountStr,
+        orderAmountCent: order.totalAmountCent,
+      });
+      return WEBHOOK_RESPONSE_FAILURE;
+    }
+
+    await this.applyRewards(order);
+
+    order.status = AlipayTradeStatus.SUCCESS;
+    order.alipayTradeNo = notify.trade_no;
+    order.buyerUserId = notify.buyer_id;
+    order.buyerLogonId = notify.buyer_logon_id;
+    order.gmtPayment = notify.gmt_payment ? new Date(notify.gmt_payment) : undefined;
+    order.rawNotify = { ...notify };
+    order.updatedAt = new Date();
+    await this.alipayOrderRepository.update(order);
+
+    await this.analyticsPurchaseService.alipayPurchase(order);
+
+    return WEBHOOK_RESPONSE_SUCCESS;
+  }
+
+  /**
+   * 根据 productCode 调用对应的奖励服务。
+   * - member: MembersService.createMember（month=quantity）
+   * - points: PlayerService.upsertAddPoint（积分按 quantity 倍发）
+   */
+  async applyRewards(order: AlipayOrder): Promise<void> {
+    const spec = ALIPAY_PRODUCT_TABLE[order.productCode];
+    if (!spec) {
+      throw new BadRequestException(`Unknown productCode: ${order.productCode}`);
+    }
+    const reward = spec.reward;
+    if (reward.kind === 'member') {
+      await this.membersService.createMember({
+        steamId: order.steamId,
+        month: order.quantity,
+        level: reward.level,
+      });
+    } else {
+      await this.playerService.upsertAddPoint(order.steamId, {
+        memberPointTotal: reward.points * order.quantity,
+      });
+    }
   }
 
   /**

--- a/api/src/alipay/dto/alipay-notify.dto.ts
+++ b/api/src/alipay/dto/alipay-notify.dto.ts
@@ -1,0 +1,24 @@
+/**
+ * 支付宝异步通知字段（application/x-www-form-urlencoded）
+ *
+ * 仅声明业务必需的字段，其他字段一并保留在 rawNotify 中。
+ * 字段名与支付宝下行参数保持一致（snake_case）。
+ *
+ * 参考：https://opendocs.alipay.com/open/204/105301
+ */
+export interface AlipayNotifyDto {
+  notify_id?: string;
+  notify_type?: string;
+  notify_time?: string;
+  app_id?: string;
+  sign?: string;
+  sign_type?: string;
+  out_trade_no?: string;
+  trade_no?: string;
+  trade_status?: string;
+  total_amount?: string;
+  buyer_id?: string;
+  buyer_logon_id?: string;
+  gmt_payment?: string;
+  [key: string]: string | undefined;
+}

--- a/api/src/alipay/dto/query-alipay-order-response.dto.ts
+++ b/api/src/alipay/dto/query-alipay-order-response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { AlipayTradeStatus } from '../enums/alipay-trade-status.enum';
+
+export class QueryAlipayOrderResponseDto {
+  @ApiProperty()
+  outTradeNo!: string;
+
+  @ApiProperty({ enum: AlipayTradeStatus })
+  status!: AlipayTradeStatus;
+}

--- a/api/src/alipay/dto/query-alipay-order.dto.ts
+++ b/api/src/alipay/dto/query-alipay-order.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class QueryAlipayOrderDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  outTradeNo!: string;
+}

--- a/api/src/alipay/entities/alipay-order.entity.ts
+++ b/api/src/alipay/entities/alipay-order.entity.ts
@@ -3,7 +3,7 @@ import { Collection } from 'fireorm';
 import { AlipayProductCode } from '../enums/alipay-product-code.enum';
 import { AlipayTradeStatus } from '../enums/alipay-trade-status.enum';
 
-@Collection('alipay-order')
+@Collection()
 export class AlipayOrder {
   id: string;
   /** 商家订单号 */

--- a/api/src/analytics/analytics.purchase.service.ts
+++ b/api/src/analytics/analytics.purchase.service.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@nestjs/common';
 
 import { AfdianOrder } from '../afdian/entities/afdian-order.entity';
+import { AlipayOrder } from '../alipay/entities/alipay-order.entity';
 import { KofiOrder } from '../kofi/entities/kofi-order.entity';
 import { KofiType } from '../kofi/enums/kofi-type.enum';
 
 import { AnalyticsService } from './analytics.service';
 
 type CURRENCY = 'CNY' | 'USD';
-type AFFILIATION = 'afdian' | 'kofi';
+type AFFILIATION = 'afdian' | 'kofi' | 'alipay';
 
 export interface PurchaseEvent {
   name: string;
@@ -94,6 +95,31 @@ export class AnalyticsPurchaseService {
         affiliation: 'kofi',
         currency: 'USD',
         transaction_id: order.messageId,
+        value: price,
+      },
+    };
+
+    await this.analyticsService.sendEvent(order.steamId.toString(), event);
+  }
+
+  async alipayPurchase(order: AlipayOrder) {
+    const price = order.totalAmountCent / 100;
+
+    const event: PurchaseEvent = {
+      name: 'purchase',
+      params: {
+        items: [
+          {
+            item_id: order.productCode,
+            item_name: `alipay-${order.productCode}`,
+            affiliation: 'alipay',
+            price,
+            currency: 'CNY',
+          },
+        ],
+        affiliation: 'alipay',
+        currency: 'CNY',
+        transaction_id: order.outTradeNo,
         value: price,
       },
     };

--- a/api/src/analytics/analytics.purchase.service.ts
+++ b/api/src/analytics/analytics.purchase.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { AfdianOrder } from '../afdian/entities/afdian-order.entity';
+import { OrderType } from '../afdian/enums/order-type.enum';
 import { AlipayOrder } from '../alipay/entities/alipay-order.entity';
 import { KofiOrder } from '../kofi/entities/kofi-order.entity';
 import { KofiType } from '../kofi/enums/kofi-type.enum';
@@ -19,6 +20,7 @@ export interface PurchaseEvent {
       affiliation: AFFILIATION;
       price: number;
       currency: CURRENCY;
+      quantity: number;
     }[];
     affiliation: AFFILIATION;
     currency: CURRENCY;
@@ -33,6 +35,11 @@ export class AnalyticsPurchaseService {
 
   async afdianPurchase(afdianOrder: AfdianOrder) {
     const price = Number(afdianOrder.orderDto.total_amount);
+    const orderType = afdianOrder.orderType;
+    const isMember = orderType === OrderType.memberNormal || orderType === OrderType.memberPremium;
+    const quantity = isMember
+      ? afdianOrder.orderDto.month
+      : Number(afdianOrder.orderDto.sku_detail[0]?.count ?? 1);
 
     const event: PurchaseEvent = {
       name: 'purchase',
@@ -44,6 +51,7 @@ export class AnalyticsPurchaseService {
             affiliation: 'afdian',
             price,
             currency: 'CNY',
+            quantity,
           },
         ],
         affiliation: 'afdian',
@@ -80,6 +88,11 @@ export class AnalyticsPurchaseService {
         item_id = 'kofi-shop-order';
         break;
     }
+    const quantity =
+      order.type === KofiType.SHOP_ORDER
+        ? (order.shopItems?.[0]?.quantity ?? 1)
+        : Number((order.amount / 4).toFixed(1));
+
     const event: PurchaseEvent = {
       name: 'purchase',
       params: {
@@ -90,6 +103,7 @@ export class AnalyticsPurchaseService {
             affiliation: 'kofi',
             price,
             currency: 'USD',
+            quantity,
           },
         ],
         affiliation: 'kofi',
@@ -115,6 +129,7 @@ export class AnalyticsPurchaseService {
             affiliation: 'alipay',
             price,
             currency: 'CNY',
+            quantity: order.quantity,
           },
         ],
         affiliation: 'alipay',

--- a/api/src/analytics/analytics.service.ts
+++ b/api/src/analytics/analytics.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { logger } from 'firebase-functions/v2';
 
 import { ResetPlayerPropertyDto } from '../player-info/dto/reset-player-property.dto';
 import { SECRET, SERVER_TYPE, SecretService } from '../util/secret/secret.service';
@@ -200,27 +201,45 @@ export class AnalyticsService {
       return true;
     }
 
-    const apiSecret = this.secretService.getSecretValue(SECRET.GA4_API_SECRET);
+    // GA4 best-effort：网络错误或非 204 一律仅 log，不抛错给上游业务（如 webhook）
+    try {
+      const apiSecret = this.secretService.getSecretValue(SECRET.GA4_API_SECRET);
 
-    const payload = {
-      client_id: userId,
-      user_id: userId,
-      non_personalized_ads: false,
-      events: [event],
-      user_properties: userProperties,
-    };
+      const payload = {
+        client_id: userId,
+        user_id: userId,
+        non_personalized_ads: false,
+        events: [event],
+        user_properties: userProperties,
+      };
 
-    const response = await fetch(
-      `${this.measurementProtocolUrl}?measurement_id=${this.measurementId}&api_secret=${apiSecret}`,
-      {
-        method: 'POST',
-        body: JSON.stringify(payload),
-        headers: {
-          'Content-Type': 'application/json',
+      const response = await fetch(
+        `${this.measurementProtocolUrl}?measurement_id=${this.measurementId}&api_secret=${apiSecret}`,
+        {
+          method: 'POST',
+          body: JSON.stringify(payload),
+          headers: {
+            'Content-Type': 'application/json',
+          },
         },
-      },
-    );
+      );
 
-    return response.status === 204;
+      if (response.status !== 204) {
+        logger.warn('[Analytics] GA4 sendEvent 非 204', {
+          userId,
+          eventName: event.name,
+          status: response.status,
+        });
+        return false;
+      }
+      return true;
+    } catch (err) {
+      logger.error('[Analytics] GA4 sendEvent 异常', {
+        userId,
+        eventName: event.name,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
   }
 }

--- a/api/test/alipay.e2e-spec.ts
+++ b/api/test/alipay.e2e-spec.ts
@@ -17,7 +17,24 @@ import { createPlayer, getMemberDto, getPlayer } from './util/util-player';
  *   - mock 整个 AlipayApiService（precreate 不走外网，verifyNotifySign 由测试控制开关）
  *   - 其余链路（Firestore emulator / Members / Player / Analytics）保持真实
  *   - GA4 sendEvent 走真实代码但不会真发外网，断言落到「调用了 alipayPurchase」即可
+ *
+ * steamId 分配规则：每个 case 独立 steamId，避免跨 case 状态污染。
  */
+const STEAM_IDS = {
+  CREATE_MEMBER: 300010001,
+  CREATE_POINTS_QTY2: 300010002,
+  CREATE_UNKNOWN_CODE: 300010003,
+  CREATE_QTY_ZERO: 300010004,
+  WEBHOOK_MEMBER_QTY1: 300010005,
+  WEBHOOK_MEMBER_QTY3: 300010006,
+  WEBHOOK_POINTS_QTY2: 300010007,
+  WEBHOOK_TRADE_FINISHED: 300010008,
+  WEBHOOK_SIGN_INVALID: 300010009,
+  WEBHOOK_AMOUNT_MISMATCH: 300010010,
+  WEBHOOK_WAIT_BUYER_PAY: 300010011,
+  WEBHOOK_IDEMPOTENT: 300010012,
+} as const;
+
 describe('AlipayController (e2e)', () => {
   let app: INestApplication;
   const prefixPath = '/api/alipay';
@@ -39,15 +56,9 @@ describe('AlipayController (e2e)', () => {
     AppGlobalSettings(app);
     await app.init();
 
-    await createPlayer(app, { steamId: 300010001 });
-    await createPlayer(app, { steamId: 300010002 });
-    await createPlayer(app, { steamId: 300010003 });
-    await createPlayer(app, { steamId: 300010004 });
-    await createPlayer(app, { steamId: 300010005 });
-    await createPlayer(app, { steamId: 300010006 });
-    await createPlayer(app, { steamId: 300010007 });
-    await createPlayer(app, { steamId: 300010008 });
-    await createPlayer(app, { steamId: 300010009 });
+    for (const steamId of Object.values(STEAM_IDS)) {
+      await createPlayer(app, { steamId });
+    }
   });
 
   afterAll(async () => {
@@ -97,13 +108,14 @@ describe('AlipayController (e2e)', () => {
 
   describe('POST /alipay/order/create', () => {
     it('单份会员订单：返回 outTradeNo / qrCode / totalAmount=28.00，DB 写 WAITING', async () => {
+      const steamId = STEAM_IDS.CREATE_MEMBER;
       const res = await createOrder({
-        steamId: 300010001,
+        steamId,
         productCode: AlipayProductCode.MEMBER_PREMIUM,
       });
 
       expect(res.status).toBe(201);
-      expect(res.body.outTradeNo).toMatch(/^ali-300010001-\d+-[a-z0-9]{4}$/);
+      expect(res.body.outTradeNo).toMatch(new RegExp(`^ali-${steamId}-\\d+-[a-z0-9]{4}$`));
       expect(res.body.totalAmount).toBe('28.00');
       expect(res.body.qrCode).toMatch(/^https:\/\/qr\.alipay\.com\//);
       expect(precreateMock).toHaveBeenCalledTimes(1);
@@ -115,7 +127,7 @@ describe('AlipayController (e2e)', () => {
 
     it('积分订单 quantity=2：totalAmount 按倍乘', async () => {
       const res = await createOrder({
-        steamId: 300010002,
+        steamId: STEAM_IDS.CREATE_POINTS_QTY2,
         productCode: AlipayProductCode.POINTS_TIER1,
         quantity: 2,
       });
@@ -126,7 +138,7 @@ describe('AlipayController (e2e)', () => {
 
     it('未知 productCode → 400', async () => {
       const res = await createOrder({
-        steamId: 300010003,
+        steamId: STEAM_IDS.CREATE_UNKNOWN_CODE,
         productCode: 'NOT_A_REAL_CODE' as AlipayProductCode,
       });
       expect(res.status).toBe(400);
@@ -134,7 +146,7 @@ describe('AlipayController (e2e)', () => {
 
     it('quantity=0 → 400', async () => {
       const res = await createOrder({
-        steamId: 300010003,
+        steamId: STEAM_IDS.CREATE_QTY_ZERO,
         productCode: AlipayProductCode.MEMBER_PREMIUM,
         quantity: 0,
       });
@@ -158,7 +170,7 @@ describe('AlipayController (e2e)', () => {
 
   describe('POST /alipay/webhook - 成功路径', () => {
     it('MEMBER_PREMIUM quantity=1：响应 success（text/plain）+ 订单 SUCCESS + 会员/积分到账', async () => {
-      const steamId = 300010004;
+      const steamId = STEAM_IDS.WEBHOOK_MEMBER_QTY1;
       const order = await createOrder({
         steamId,
         productCode: AlipayProductCode.MEMBER_PREMIUM,
@@ -185,7 +197,7 @@ describe('AlipayController (e2e)', () => {
     });
 
     it('MEMBER_PREMIUM quantity=3：发放 3 个月会员（积分 +3000）', async () => {
-      const steamId = 300010005;
+      const steamId = STEAM_IDS.WEBHOOK_MEMBER_QTY3;
       const order = await createOrder({
         steamId,
         productCode: AlipayProductCode.MEMBER_PREMIUM,
@@ -203,7 +215,7 @@ describe('AlipayController (e2e)', () => {
     });
 
     it('POINTS_TIER1 quantity=2：积分 +7000（无 member 记录）', async () => {
-      const steamId = 300010006;
+      const steamId = STEAM_IDS.WEBHOOK_POINTS_QTY2;
       const order = await createOrder({
         steamId,
         productCode: AlipayProductCode.POINTS_TIER1,
@@ -224,7 +236,7 @@ describe('AlipayController (e2e)', () => {
     });
 
     it('TRADE_FINISHED 也按成功处理', async () => {
-      const steamId = 300010007;
+      const steamId = STEAM_IDS.WEBHOOK_TRADE_FINISHED;
       const order = await createOrder({
         steamId,
         productCode: AlipayProductCode.MEMBER_PREMIUM,
@@ -243,7 +255,7 @@ describe('AlipayController (e2e)', () => {
 
   describe('POST /alipay/webhook - 异常路径', () => {
     it('验签失败：返回 failure，订单仍 WAITING，无奖励', async () => {
-      const steamId = 300010008;
+      const steamId = STEAM_IDS.WEBHOOK_SIGN_INVALID;
       const order = await createOrder({
         steamId,
         productCode: AlipayProductCode.MEMBER_PREMIUM,
@@ -263,7 +275,7 @@ describe('AlipayController (e2e)', () => {
 
     it('金额不匹配：返回 failure，订单不变', async () => {
       const order = await createOrder({
-        steamId: 300010009,
+        steamId: STEAM_IDS.WEBHOOK_AMOUNT_MISMATCH,
         productCode: AlipayProductCode.MEMBER_PREMIUM,
       });
       const outTradeNo = order.body.outTradeNo;
@@ -279,7 +291,7 @@ describe('AlipayController (e2e)', () => {
 
     it('trade_status=WAIT_BUYER_PAY：返回 failure', async () => {
       const order = await createOrder({
-        steamId: 300010001,
+        steamId: STEAM_IDS.WEBHOOK_WAIT_BUYER_PAY,
         productCode: AlipayProductCode.MEMBER_PREMIUM,
       });
       const outTradeNo = order.body.outTradeNo;
@@ -306,7 +318,7 @@ describe('AlipayController (e2e)', () => {
 
   describe('POST /alipay/webhook - 幂等', () => {
     it('重发同一 webhook：第 2 次返回 success 但奖励不重复发放', async () => {
-      const steamId = 300010002;
+      const steamId = STEAM_IDS.WEBHOOK_IDEMPOTENT;
       const order = await createOrder({
         steamId,
         productCode: AlipayProductCode.POINTS_TIER1,

--- a/api/test/alipay.e2e-spec.ts
+++ b/api/test/alipay.e2e-spec.ts
@@ -1,0 +1,332 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+
+import { AlipayApiService } from '../src/alipay/alipay.api.service';
+import { AlipayProductCode } from '../src/alipay/enums/alipay-product-code.enum';
+import { AlipayTradeStatus } from '../src/alipay/enums/alipay-trade-status.enum';
+import { AppModule } from '../src/app.module';
+import { MemberLevel } from '../src/members/entities/members.entity';
+import { AppGlobalSettings } from '../src/util/settings';
+
+import { createPlayer, getMemberDto, getPlayer } from './util/util-player';
+
+/**
+ * Alipay e2e：
+ *   - mock 整个 AlipayApiService（precreate 不走外网，verifyNotifySign 由测试控制开关）
+ *   - 其余链路（Firestore emulator / Members / Player / Analytics）保持真实
+ *   - GA4 sendEvent 走真实代码但不会真发外网，断言落到「调用了 alipayPurchase」即可
+ */
+describe('AlipayController (e2e)', () => {
+  let app: INestApplication;
+  const prefixPath = '/api/alipay';
+
+  // 让测试可控的 mock：默认验签通过，单独 case 可设 false 模拟伪造
+  let signValid = true;
+  const precreateMock = jest.fn(async () => 'https://qr.alipay.com/mock-' + Date.now());
+  const verifyMock = jest.fn(() => signValid);
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(AlipayApiService)
+      .useValue({ precreate: precreateMock, verifyNotifySign: verifyMock })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    AppGlobalSettings(app);
+    await app.init();
+
+    await createPlayer(app, { steamId: 300010001 });
+    await createPlayer(app, { steamId: 300010002 });
+    await createPlayer(app, { steamId: 300010003 });
+    await createPlayer(app, { steamId: 300010004 });
+    await createPlayer(app, { steamId: 300010005 });
+    await createPlayer(app, { steamId: 300010006 });
+    await createPlayer(app, { steamId: 300010007 });
+    await createPlayer(app, { steamId: 300010008 });
+    await createPlayer(app, { steamId: 300010009 });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    signValid = true;
+    precreateMock.mockClear();
+    verifyMock.mockClear();
+  });
+
+  const apiKey = 'Invalid_NotOnDedicatedServer';
+
+  const buildNotify = (overrides: Record<string, string> = {}) => ({
+    out_trade_no: '',
+    trade_status: 'TRADE_SUCCESS',
+    total_amount: '28.00',
+    trade_no: '2026050322001400000000001',
+    buyer_id: '2088000000000001',
+    buyer_logon_id: 'sandbox***@example.com',
+    gmt_payment: '2026-05-03 20:00:00',
+    sign: 'mock-sign',
+    sign_type: 'RSA2',
+    notify_id: 'mock-notify-id',
+    ...overrides,
+  });
+
+  const createOrder = async (body: {
+    steamId: number;
+    productCode: AlipayProductCode;
+    quantity?: number;
+  }) =>
+    request(app.getHttpServer())
+      .post(`${prefixPath}/order/create`)
+      .set('x-api-key', apiKey)
+      .send(body);
+
+  const queryOrder = async (outTradeNo: string) =>
+    request(app.getHttpServer())
+      .get(`${prefixPath}/order/query`)
+      .set('x-api-key', apiKey)
+      .query({ outTradeNo });
+
+  const postWebhook = async (notify: Record<string, string>) =>
+    request(app.getHttpServer()).post(`${prefixPath}/webhook`).type('form').send(notify);
+
+  describe('POST /alipay/order/create', () => {
+    it('单份会员订单：返回 outTradeNo / qrCode / totalAmount=28.00，DB 写 WAITING', async () => {
+      const res = await createOrder({
+        steamId: 300010001,
+        productCode: AlipayProductCode.MEMBER_PREMIUM,
+      });
+
+      expect(res.status).toBe(201);
+      expect(res.body.outTradeNo).toMatch(/^ali-300010001-\d+-[a-z0-9]{4}$/);
+      expect(res.body.totalAmount).toBe('28.00');
+      expect(res.body.qrCode).toMatch(/^https:\/\/qr\.alipay\.com\//);
+      expect(precreateMock).toHaveBeenCalledTimes(1);
+
+      const status = await queryOrder(res.body.outTradeNo);
+      expect(status.status).toBe(200);
+      expect(status.body.status).toBe(AlipayTradeStatus.WAITING);
+    });
+
+    it('积分订单 quantity=2：totalAmount 按倍乘', async () => {
+      const res = await createOrder({
+        steamId: 300010002,
+        productCode: AlipayProductCode.POINTS_TIER1,
+        quantity: 2,
+      });
+
+      expect(res.status).toBe(201);
+      expect(res.body.totalAmount).toBe('156.00');
+    });
+
+    it('未知 productCode → 400', async () => {
+      const res = await createOrder({
+        steamId: 300010003,
+        productCode: 'NOT_A_REAL_CODE' as AlipayProductCode,
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('quantity=0 → 400', async () => {
+      const res = await createOrder({
+        steamId: 300010003,
+        productCode: AlipayProductCode.MEMBER_PREMIUM,
+        quantity: 0,
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /alipay/order/query', () => {
+    it('订单不存在 → 404', async () => {
+      const res = await queryOrder('ali-not-exist');
+      expect(res.status).toBe(404);
+    });
+
+    it('缺 outTradeNo 参数 → 400', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`${prefixPath}/order/query`)
+        .set('x-api-key', apiKey);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /alipay/webhook - 成功路径', () => {
+    it('MEMBER_PREMIUM quantity=1：响应 success（text/plain）+ 订单 SUCCESS + 会员/积分到账', async () => {
+      const steamId = 300010004;
+      const order = await createOrder({
+        steamId,
+        productCode: AlipayProductCode.MEMBER_PREMIUM,
+      });
+      const outTradeNo = order.body.outTradeNo;
+
+      const res = await postWebhook(buildNotify({ out_trade_no: outTradeNo }));
+
+      // NestJS @Post 默认 201；webhook 只要 2xx + 纯文本 'success' 支付宝就认为成功
+      expect(res.status).toBeGreaterThanOrEqual(200);
+      expect(res.status).toBeLessThan(300);
+      expect(res.text).toBe('success');
+      expect(res.headers['content-type']).toMatch(/text\/plain/);
+
+      const status = await queryOrder(outTradeNo);
+      expect(status.body.status).toBe(AlipayTradeStatus.SUCCESS);
+
+      const member = await getMemberDto(app, steamId);
+      expect(member.level).toBe(MemberLevel.PREMIUM);
+      expect(member.enable).toBe(true);
+
+      const player = await getPlayer(app, steamId);
+      expect(player.memberPointTotal).toBe(1000);
+    });
+
+    it('MEMBER_PREMIUM quantity=3：发放 3 个月会员（积分 +3000）', async () => {
+      const steamId = 300010005;
+      const order = await createOrder({
+        steamId,
+        productCode: AlipayProductCode.MEMBER_PREMIUM,
+        quantity: 3,
+      });
+      const outTradeNo = order.body.outTradeNo;
+
+      const res = await postWebhook(
+        buildNotify({ out_trade_no: outTradeNo, total_amount: '84.00' }),
+      );
+
+      expect(res.text).toBe('success');
+      const player = await getPlayer(app, steamId);
+      expect(player.memberPointTotal).toBe(3000); // 1000 * 3 个月
+    });
+
+    it('POINTS_TIER1 quantity=2：积分 +7000（无 member 记录）', async () => {
+      const steamId = 300010006;
+      const order = await createOrder({
+        steamId,
+        productCode: AlipayProductCode.POINTS_TIER1,
+        quantity: 2,
+      });
+      const outTradeNo = order.body.outTradeNo;
+
+      const res = await postWebhook(
+        buildNotify({ out_trade_no: outTradeNo, total_amount: '156.00' }),
+      );
+
+      expect(res.text).toBe('success');
+      const player = await getPlayer(app, steamId);
+      expect(player.memberPointTotal).toBe(7000);
+
+      // 积分订单不应创建 member 记录
+      await expect(getMemberDto(app, steamId)).rejects.toThrow();
+    });
+
+    it('TRADE_FINISHED 也按成功处理', async () => {
+      const steamId = 300010007;
+      const order = await createOrder({
+        steamId,
+        productCode: AlipayProductCode.MEMBER_PREMIUM,
+      });
+      const outTradeNo = order.body.outTradeNo;
+
+      const res = await postWebhook(
+        buildNotify({ out_trade_no: outTradeNo, trade_status: 'TRADE_FINISHED' }),
+      );
+
+      expect(res.text).toBe('success');
+      const status = await queryOrder(outTradeNo);
+      expect(status.body.status).toBe(AlipayTradeStatus.SUCCESS);
+    });
+  });
+
+  describe('POST /alipay/webhook - 异常路径', () => {
+    it('验签失败：返回 failure，订单仍 WAITING，无奖励', async () => {
+      const steamId = 300010008;
+      const order = await createOrder({
+        steamId,
+        productCode: AlipayProductCode.MEMBER_PREMIUM,
+      });
+      const outTradeNo = order.body.outTradeNo;
+
+      signValid = false;
+      const res = await postWebhook(buildNotify({ out_trade_no: outTradeNo }));
+
+      expect(res.text).toBe('failure');
+      const status = await queryOrder(outTradeNo);
+      expect(status.body.status).toBe(AlipayTradeStatus.WAITING);
+
+      const player = await getPlayer(app, steamId);
+      expect(player.memberPointTotal).toBe(0);
+    });
+
+    it('金额不匹配：返回 failure，订单不变', async () => {
+      const order = await createOrder({
+        steamId: 300010009,
+        productCode: AlipayProductCode.MEMBER_PREMIUM,
+      });
+      const outTradeNo = order.body.outTradeNo;
+
+      const res = await postWebhook(
+        buildNotify({ out_trade_no: outTradeNo, total_amount: '0.01' }),
+      );
+
+      expect(res.text).toBe('failure');
+      const status = await queryOrder(outTradeNo);
+      expect(status.body.status).toBe(AlipayTradeStatus.WAITING);
+    });
+
+    it('trade_status=WAIT_BUYER_PAY：返回 failure', async () => {
+      const order = await createOrder({
+        steamId: 300010001,
+        productCode: AlipayProductCode.MEMBER_PREMIUM,
+      });
+      const outTradeNo = order.body.outTradeNo;
+
+      const res = await postWebhook(
+        buildNotify({ out_trade_no: outTradeNo, trade_status: 'WAIT_BUYER_PAY' }),
+      );
+
+      expect(res.text).toBe('failure');
+    });
+
+    it('缺 out_trade_no：返回 failure', async () => {
+      const notify = buildNotify();
+      delete (notify as any).out_trade_no;
+      const res = await postWebhook(notify);
+      expect(res.text).toBe('failure');
+    });
+
+    it('订单不存在：返回 failure', async () => {
+      const res = await postWebhook(buildNotify({ out_trade_no: 'ali-not-exist' }));
+      expect(res.text).toBe('failure');
+    });
+  });
+
+  describe('POST /alipay/webhook - 幂等', () => {
+    it('重发同一 webhook：第 2 次返回 success 但奖励不重复发放', async () => {
+      const steamId = 300010002;
+      const order = await createOrder({
+        steamId,
+        productCode: AlipayProductCode.POINTS_TIER1,
+      });
+      const outTradeNo = order.body.outTradeNo;
+      const beforePoints = (await getPlayer(app, steamId)).memberPointTotal;
+
+      const r1 = await postWebhook(
+        buildNotify({ out_trade_no: outTradeNo, total_amount: '78.00' }),
+      );
+      expect(r1.text).toBe('success');
+      const afterFirst = (await getPlayer(app, steamId)).memberPointTotal;
+      expect(afterFirst - beforePoints).toBe(3500);
+
+      const r2 = await postWebhook(
+        buildNotify({ out_trade_no: outTradeNo, total_amount: '78.00' }),
+      );
+      expect(r2.text).toBe('success');
+      const afterSecond = (await getPlayer(app, steamId)).memberPointTotal;
+      expect(afterSecond).toBe(afterFirst); // 不重复加
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /api/alipay/order/query` 读 Firestore 返回 `{ outTradeNo, status }`
- `POST /api/alipay/webhook`：验签 → 必填字段 → 订单查找 → 幂等 → trade_status / 金额校验 → 应用奖励 → 写 SUCCESS → GA4 `purchase`
- `AlipayService.applyRewards` 复用 `MembersService.createMember` 与 `PlayerService.upsertAddPoint`（积分按 quantity 倍发）
- `AlipayApiService.verifyNotifySign` 包装 alipay-sdk `checkNotifySignV2`
- `AnalyticsPurchaseService.alipayPurchase`（CNY、affiliation=alipay、transaction_id=outTradeNo）

## 安全要点
- 验签是 webhook 处理的第一步，失败立即返回 `failure`，不触碰 Firestore；e2e 与单测均覆盖该顺序
- 金额按「分」整数比对，避免浮点误差
- 幂等基于 `AlipayOrder.id = outTradeNo` + `status === SUCCESS`，重复回调返回 `success` 但不重发奖
- Webhook 路由 `@Public()`、`Content-Type: text/plain`，按支付宝规范回纯文本

Closes #860

## Test plan

### 自动测试（已通过，覆盖原 issue 全部检查点）

**单元测试 — `npx jest`：92/92 passed**
- 见 `api/src/alipay/alipay.service.spec.ts`，新增 16 个 webhook/query case：
  - 验签失败、金额不符、trade_status 非成功、缺必填字段、订单不存在、幂等
  - 会员 quantity=1/3、各积分档位按 quantity 倍发、TRADE_FINISHED 成功、安全顺序

**E2E 测试 — `npm run test:e2e`：181/181 passed（9 suites）**
- 见 `api/test/alipay.e2e-spec.ts`，用 `Test.overrideProvider` mock 掉 `AlipayApiService`（precreate 不走外网、verifyNotifySign 由 `signValid` 开关控制），其余链路（Firestore emulator / Members / Player / Analytics）保持真实
- 16 个 case 自动覆盖原 issue 验收清单：

| 验收点 | E2E 覆盖 |
|---|---|
| 创建订单返回 outTradeNo / qrCode / WAITING | ✅ |
| 查询接口返回 WAITING → SUCCESS | ✅ |
| Webhook → 订单 status: WAITING → SUCCESS | ✅ |
| MEMBER_PREMIUM 会员 + 积分到账（quantity=1, =3） | ✅ |
| POINTS_TIER1 quantity=2 → 积分 +7000 | ✅ |
| 重发同一 webhook → success + 不重复发奖 | ✅ |
| 验签失败 / 金额不符 / trade_status 非成功 → failure | ✅ |
| 不存在订单 / 缺 out_trade_no → failure | ✅ |
| 响应 Content-Type: text/plain | ✅ |

### 仍需手动验收

sandbox环境 

- [x] 创建订单
- [x] 查询waiting
- [x] webhook 回调
- [x] GA4 事件真发到 Google Analytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)