### PR TITLE
Fix(web): sync package-lock.json after next-intl bump to 4.9.2

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7074,6 +7074,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",


### PR DESCRIPTION
next-intl@4.9.2 requires @swc/helpers@0.5.21 as a nested dep, which was missing from the lock file after PR #873, causing GCP build to fail with "npm ci" out-of-sync error.