### PR TITLE
Fix(web): sync package-lock.json after next@15.5.18 bump

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7074,6 +7074,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",


### PR DESCRIPTION
## Summary

- PR #885 bumped `next` from 15.5.18 via dependabot, but the lock file update only changed the `next` package version entries without running a full `npm install`
- `next-intl`'s nested `@swc/helpers@0.5.21` peer-dependency entry was missing from `web/package-lock.json`
- Firebase App Hosting runs `npm ci` which requires the lock file to be in sync — this caused the build to fail with `Missing: @swc/helpers@0.5.21 from lock file`
- Fix: ran `npm install` in `web/` to regenerate the lock file with the missing entry

## Test plan

- [ ] Firebase App Hosting build should succeed after this is merged to main

https://claude.ai/code/session_01KR563nerKYGCx4syDQKtxq

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR563nerKYGCx4syDQKtxq)_