### PR TITLE
Fix(ci): use npm ci instead of npm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
           java-version: '21'
 
       - name: Set API
-        run: (cd api && npm install)
+        run: (cd api && npm ci)
       - name: Set Web
-        run: (cd web && npm install)
+        run: (cd web && npm ci)
       - name: Set firebase
         run: |
           npm install -g firebase-tools

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7074,6 +7074,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",


### PR DESCRIPTION
## Summary

- 将 CI 中的 `npm install` 改为 `npm ci`
- `npm install` 发现 lock 文件不同步时会静默修复，导致 #885 这类问题无法在 PR 阶段被发现
- 改用 `npm ci` 后，lock 文件与 package.json 不一致时 CI 会直接报错，与 Firebase App Hosting 构建行为一致

## Test plan

- [ ] CI 在 lock 文件正常时应正常通过
- [ ] CI 在 lock 文件不同步时应报错（与 Firebase App Hosting 一致）

https://claude.ai/code/session_01KR563nerKYGCx4syDQKtxq

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR563nerKYGCx4syDQKtxq)_