### PR TITLE
Revert(analytics): gameEndItemBuilds facetId to confirm game_end_bot event reduction

### DIFF
--- a/api/src/analytics/analytics.controller.ts
+++ b/api/src/analytics/analytics.controller.ts
@@ -5,6 +5,7 @@ import { Request } from 'express';
 import { SecretService } from '../util/secret/secret.service';
 
 import { AnalyticsService } from './analytics.service';
+import { ItemListDto } from './dto/pick-item-dto';
 import { PlayerLanguageListDto } from './dto/player-language-dto';
 
 @ApiTags('Analytics(GA4)')
@@ -14,6 +15,14 @@ export class AnalyticsController {
     private readonly analyticsService: AnalyticsService,
     private readonly secretService: SecretService,
   ) {}
+
+  /** @deprecated 临时恢复用于验证 game_end_bot event 减少原因，验证完毕后删除 */
+  @Post('/game-end/item-builds')
+  async gameEndItemBuilds(@Body() body: ItemListDto, @Req() req: Request): Promise<void> {
+    const apiKey = req.headers['x-api-key'] as string;
+    const serverType = this.secretService.getServerTypeByApiKey(apiKey);
+    await this.analyticsService.gameEndItemBuilds(body, serverType);
+  }
 
   /** @deprecated 改由客户端发送，客户端上线确认无误后删除此endpoint */
   @Post('/player/language')

--- a/api/src/analytics/analytics.service.ts
+++ b/api/src/analytics/analytics.service.ts
@@ -7,6 +7,8 @@ import { SECRET, SERVER_TYPE, SecretService } from '../util/secret/secret.servic
 import { PurchaseEvent } from './analytics.purchase.service';
 import { GetHeroId, GetHeroNameChinese } from './data/hero-data';
 import { GameEndDto as GameEndMatchDto, GameEndPlayerDto } from './dto/game-end-dto';
+import { PickListDto } from './dto/pick-ability-dto';
+import { ItemListDto } from './dto/pick-item-dto';
 import { PlayerLanguageListDto } from './dto/player-language-dto';
 
 export interface Event {
@@ -68,6 +70,62 @@ export class AnalyticsService {
     });
   }
 
+  async gameEndPickAbilities(dto: PickListDto, serverType: SERVER_TYPE) {
+    for (const pick of dto.picks) {
+      const event = await this.buildEvent('game_end_pick_ability', pick.steamId, dto.matchId, {
+        steam_id: pick.steamId,
+        match_id: dto.matchId,
+        ability_name: pick.name,
+        type: pick.type,
+        level: pick.level,
+        difficulty: dto.difficulty,
+        version: dto.version,
+        win_metrics: dto.isWin,
+        server_type: serverType,
+      });
+
+      await this.sendEvent(pick.steamId.toString(), event);
+    }
+  }
+
+  /** @deprecated 临时恢复用于验证 game_end_bot event 减少原因，验证完毕后删除 */
+  async gameEndItemBuilds(dto: ItemListDto, serverType: SERVER_TYPE) {
+    for (const playerItems of dto.items) {
+      const itemSlots = [
+        { name: playerItems.slot1, type: 'normal' },
+        { name: playerItems.slot2, type: 'normal' },
+        { name: playerItems.slot3, type: 'normal' },
+        { name: playerItems.slot4, type: 'normal' },
+        { name: playerItems.slot5, type: 'normal' },
+        { name: playerItems.slot6, type: 'normal' },
+        { name: playerItems.neutralActiveSlot, type: 'neutral_active' },
+        { name: playerItems.neutralPassiveSlot, type: 'neutral_passive' },
+      ];
+
+      for (const slot of itemSlots) {
+        if (slot.name) {
+          const event = await this.buildEvent(
+            'game_end_item_build',
+            playerItems.steamId,
+            dto.matchId,
+            {
+              steam_id: playerItems.steamId,
+              match_id: dto.matchId,
+              item_name: slot.name,
+              type: slot.type,
+              difficulty: dto.difficulty,
+              version: dto.version,
+              win_metrics: dto.isWin,
+              server_type: serverType,
+            },
+          );
+
+          await this.sendEvent(playerItems.steamId.toString(), event);
+        }
+      }
+    }
+  }
+
   async trackPlayerLanguage(dto: PlayerLanguageListDto, serverType: SERVER_TYPE) {
     await Promise.all(
       dto.players.map(async (player) => {
@@ -111,6 +169,7 @@ export class AnalyticsService {
           hero_name: player.heroName,
           hero_name_cn: GetHeroNameChinese(player.heroName),
           points: player.battlePoints,
+          facet_id: player.facetId, // @deprecated 临时恢复用于验证 game_end_bot event 减少原因，验证完毕后删除
           is_disconnect: player.isDisconnected,
           server_type: serverType,
           country: gameEnd.countryCode,

--- a/api/src/analytics/analytics.service.ts
+++ b/api/src/analytics/analytics.service.ts
@@ -7,7 +7,6 @@ import { SECRET, SERVER_TYPE, SecretService } from '../util/secret/secret.servic
 import { PurchaseEvent } from './analytics.purchase.service';
 import { GetHeroId, GetHeroNameChinese } from './data/hero-data';
 import { GameEndDto as GameEndMatchDto, GameEndPlayerDto } from './dto/game-end-dto';
-import { PickListDto } from './dto/pick-ability-dto';
 import { ItemListDto } from './dto/pick-item-dto';
 import { PlayerLanguageListDto } from './dto/player-language-dto';
 
@@ -68,24 +67,6 @@ export class AnalyticsService {
         use_member_point: dto.useMemberPoint,
       },
     });
-  }
-
-  async gameEndPickAbilities(dto: PickListDto, serverType: SERVER_TYPE) {
-    for (const pick of dto.picks) {
-      const event = await this.buildEvent('game_end_pick_ability', pick.steamId, dto.matchId, {
-        steam_id: pick.steamId,
-        match_id: dto.matchId,
-        ability_name: pick.name,
-        type: pick.type,
-        level: pick.level,
-        difficulty: dto.difficulty,
-        version: dto.version,
-        win_metrics: dto.isWin,
-        server_type: serverType,
-      });
-
-      await this.sendEvent(pick.steamId.toString(), event);
-    }
   }
 
   /** @deprecated 临时恢复用于验证 game_end_bot event 减少原因，验证完毕后删除 */

--- a/api/src/analytics/dto/game-end-dto.ts
+++ b/api/src/analytics/dto/game-end-dto.ts
@@ -39,6 +39,8 @@ export class GameEndPlayerDto {
   score: number;
   @ApiProperty()
   battlePoints: number;
+  @ApiProperty()
+  facetId: number;
 }
 
 export class GameEndDto extends EventBaseDto {

--- a/api/src/analytics/dto/game-end-dto.ts
+++ b/api/src/analytics/dto/game-end-dto.ts
@@ -39,6 +39,7 @@ export class GameEndPlayerDto {
   score: number;
   @ApiProperty()
   battlePoints: number;
+  // TODO: 临时恢复用于验证 game_end_bot event 减少原因，验证完毕后删除
   @ApiProperty()
   facetId: number;
 }

--- a/api/src/analytics/dto/pick-item-dto.ts
+++ b/api/src/analytics/dto/pick-item-dto.ts
@@ -1,0 +1,50 @@
+import { ApiProperty, OmitType } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsOptional, ValidateNested } from 'class-validator';
+
+import { EventBaseDto } from './event-base-dto';
+
+export class ItemBuildDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  steamId: number;
+
+  @ApiProperty({ default: 'item_slot1_name', required: false })
+  @IsOptional()
+  slot1?: string;
+
+  @ApiProperty({ default: 'item_slot2_name', required: false })
+  @IsOptional()
+  slot2?: string;
+
+  @ApiProperty({ default: 'item_slot3_name', required: false })
+  @IsOptional()
+  slot3?: string;
+
+  @ApiProperty({ default: 'item_slot4_name', required: false })
+  @IsOptional()
+  slot4?: string;
+
+  @ApiProperty({ default: 'item_slot5_name', required: false })
+  @IsOptional()
+  slot5?: string;
+
+  @ApiProperty({ default: 'item_slot6_name', required: false })
+  @IsOptional()
+  slot6?: string;
+
+  @ApiProperty({ default: 'neutral_active_item_name', required: false })
+  @IsOptional()
+  neutralActiveSlot?: string;
+
+  @ApiProperty({ default: 'neutral_passive_item_name', required: false })
+  @IsOptional()
+  neutralPassiveSlot?: string;
+}
+
+export class ItemListDto extends OmitType(EventBaseDto, ['steamId']) {
+  @ApiProperty({ type: [ItemBuildDto] })
+  @ValidateNested({ each: true })
+  @Type(() => ItemBuildDto)
+  items: ItemBuildDto[];
+}

--- a/api/src/analytics/dto/pick-item-dto.ts
+++ b/api/src/analytics/dto/pick-item-dto.ts
@@ -1,3 +1,4 @@
+// TODO: 临时恢复用于验证 game_end_bot event 减少原因，验证完毕后删除整个文件
 import { ApiProperty, OmitType } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsNotEmpty, IsOptional, ValidateNested } from 'class-validator';


### PR DESCRIPTION
## Summary

- Reverts commit ad65dd0 ("Remove unused code (#817)") 中删除的 `gameEndItemBuilds` endpoint 及相关 service 方法
- 同时恢复 `facetId` 字段到 `gameEndPlayerBot` event 参数中
- 所有恢复的代码均标注 `@deprecated`，验证完毕后需再次删除

## What changed

- `analytics.controller.ts`: 恢复 `POST /game-end/item-builds` endpoint，标注 deprecated
- `analytics.service.ts`: 恢复 `gameEndItemBuilds()` 方法（标注 deprecated），`facet_id` 参数行加 deprecated 注释
- `dto/pick-item-dto.ts`: 恢复被删除的 DTO 文件
- `trackPlayerLanguage` endpoint 保留原有 `@deprecated` 注释

## Why

怀疑 `game_end_bot` GA4 event 数量减少与 #817 删除 item builds 上报逻辑有关，临时恢复以验证假设。

## Reviewer notes

- `gameEndLotteryPickAbilities`（pick abilities endpoint）未被 #817 删除，本 PR 未恢复该 endpoint
- 验证结束后需跟进删除所有带 deprecated 标注的代码