### PR TITLE
feat: skip cumulative record accumulation for TENVTEN server type

### DIFF
--- a/api/src/game/game.controller.ts
+++ b/api/src/game/game.controller.ts
@@ -20,7 +20,7 @@ import { PlayerStatsLifetimeService } from '../player/player-stats-lifetime.serv
 import { PlayerService } from '../player/player.service';
 import { PlayerInfoService } from '../player-info/player-info.service';
 import { Public } from '../util/auth/public.decorator';
-import { SecretService } from '../util/secret/secret.service';
+import { SERVER_TYPE, SecretService } from '../util/secret/secret.service';
 
 import { GameStart } from './dto/game-start.response';
 import { PointInfoDto } from './dto/point-info.dto';
@@ -131,9 +131,11 @@ export class GameController {
     await Promise.all([
       this.analyticsService.gameEndMatch(gameEnd, serverType),
       this.analyticsService.gameEndPlayerBot(gameEnd, serverType),
-      ...players
-        .filter((p) => p.steamId > 0)
-        .map((p) => this.playerStatsLifetimeService.accumulate(p.steamId, p)),
+      ...(serverType !== SERVER_TYPE.TENVTEN
+        ? players
+            .filter((p) => p.steamId > 0)
+            .map((p) => this.playerStatsLifetimeService.accumulate(p.steamId, p))
+        : []),
     ]);
     return this.gameService.getOK();
   }

--- a/api/test/game.e2e-spec.ts
+++ b/api/test/game.e2e-spec.ts
@@ -989,6 +989,17 @@ describe('PlayerController (e2e)', () => {
       expect(stats1.kills).toEqual(5);
       expect(stats2.kills).toEqual(5);
     });
+
+    it('使用 Tenvten API Key 不写入 statsLifetime', async () => {
+      const steamId = 100003021;
+      await request(app.getHttpServer())
+        .post(gameEndUrl)
+        .send(createGameEndPayload({ players: [{ steamId }] }))
+        .set({ 'x-api-key': 'tenvten-apikey' });
+
+      const stats = await getPlayerStatsLifetime(app, steamId);
+      expect(stats).toBeNull();
+    });
   });
 
   describe('/api/game/start (Get) statsLifetime 随开局数据返回', () => {


### PR DESCRIPTION
## Summary

- TENVTEN 是第三方服务器，其对局数据不应计入玩家的累计战绩（PlayerStatsLifetime）
- 在 `/game/end` 的 `Promise.all` 中，当 `serverType === SERVER_TYPE.TENVTEN` 时跳过 `playerStatsLifetimeService.accumulate()` 调用
- 分析事件（GA4）仍正常发送，不受影响

## Test plan

- [x] `cd api && npm run test` — all 111 tests pass
- [x] `cd api && npm run lint` — no errors
- [x] E2E: 使用 TENVTEN API key 发送 game/end，确认 Firestore 中 PlayerStatsLifetime 文档未创建/更新

https://claude.ai/code/session_01U5zQZFAgt32A4KGNtPtvZh

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5zQZFAgt32A4KGNtPtvZh)_