### PR TITLE
fix(helper): getMemberTotalPoint returns 0 for level <= 0

### DIFF
--- a/api/src/player-info/assemblers/player-dto.assembler.ts
+++ b/api/src/player-info/assemblers/player-dto.assembler.ts
@@ -84,8 +84,7 @@ export class PlayerDtoAssembler {
 
     dto.useableSeasonPoint =
       dto.seasonPointTotal - PlayerLevelHelper.getSeasonTotalPoint(usedSeasonLevel);
-    // getMemberTotalPoint(1) = 0; clamp to 1 since level 0 is undefined in the helper
     dto.useableMemberPoint =
-      dto.memberPointTotal - PlayerLevelHelper.getMemberTotalPoint(Math.max(1, usedMemberLevel));
+      dto.memberPointTotal - PlayerLevelHelper.getMemberTotalPoint(usedMemberLevel);
   }
 }

--- a/api/src/player/helpers/player-level.helper.spec.ts
+++ b/api/src/player/helpers/player-level.helper.spec.ts
@@ -131,6 +131,10 @@ describe('PlayerLevelHelper', () => {
     });
 
     describe('等级所需累计积分', () => {
+      it('0 -> 0', () => {
+        expect(PlayerLevelHelper.getMemberTotalPoint(0)).toBe(0);
+      });
+
       it('1 -> 0', () => {
         expect(PlayerLevelHelper.getMemberTotalPoint(1)).toBe(0);
       });

--- a/api/src/player/helpers/player-level.helper.ts
+++ b/api/src/player/helpers/player-level.helper.ts
@@ -63,6 +63,7 @@ export class PlayerLevelHelper {
    * @returns 累计积分
    */
   static getMemberTotalPoint(level: number): number {
+    if (level <= 0) return 0;
     level -= 1;
     return 100 * ((level * level) / 4 + level * 9.75);
   }


### PR DESCRIPTION
## Summary

- Fix `getMemberTotalPoint(0)` returning `-950` instead of `0`
- Remove the `Math.max(1, usedMemberLevel)` workaround in the assembler that was compensating for this bug
- Add unit test for `getMemberTotalPoint(0) === 0`

## Root cause

The quadratic formula in the helper assumes `level >= 1`:

```typescript
static getMemberTotalPoint(level: number): number {
  level -= 1;  // 0 → -1
  return 100 * ((level * level) / 4 + level * 9.75);
  // = 100 * (0.25 - 9.75) = -950  ← wrong
}
```

Member level starts at 1, so `level = 0` means "no member levels consumed" → cost should be 0.

## Changes

| File | Change |
|------|--------|
| `player-level.helper.ts` | Add early return `if (level <= 0) return 0` |
| `player-level.helper.spec.ts` | Add test case `getMemberTotalPoint(0) === 0` |
| `player-dto.assembler.ts` | Remove `Math.max(1, usedMemberLevel)` workaround |

https://claude.ai/code/session_01SR26LTx2pboyzWGYwGo85p

---
_Generated by [Claude Code](https://claude.ai/code/session_01SR26LTx2pboyzWGYwGo85p)_