### PR TITLE
fix(player): filter invalid PlayerStatsLifetime stats on game/end (#908)

### DIFF
--- a/api/src/analytics/dto/game-end-dto.ts
+++ b/api/src/analytics/dto/game-end-dto.ts
@@ -1,65 +1,53 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import {
-  IsArray,
-  IsBoolean,
-  IsNotEmpty,
-  IsNumber,
-  IsOptional,
-  IsString,
-  Min,
-  ValidateNested,
-} from 'class-validator';
+import { IsArray, IsNotEmpty, IsNumber, IsOptional, Min, ValidateNested } from 'class-validator';
 
 import { EventBaseDto } from './event-base-dto';
 
 export class GameEndGameOptionsDto {
-  @ApiProperty({ default: 1 })
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
-  multiplierRadiant: number;
-  @ApiProperty({ default: 1 })
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
-  multiplierDire: number;
-  @ApiProperty({ default: 1 })
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
-  playerNumberRadiant: number;
-  @ApiProperty({ default: 1 })
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
-  playerNumberDire: number;
-  @ApiProperty({ default: 100 })
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
-  towerPowerPct: number;
-  @ApiProperty({ required: false, default: 100 })
+  @ApiProperty({ default: 1, required: false })
   @IsOptional()
   @IsNumber({ allowNaN: false, allowInfinity: false })
   @Min(0)
-  respawnTime?: number;
+  multiplierRadiant?: number;
+  @ApiProperty({ default: 1, required: false })
+  @IsOptional()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
+  multiplierDire?: number;
+  @ApiProperty({ default: 1, required: false })
+  @IsOptional()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
+  playerNumberRadiant?: number;
+  @ApiProperty({ default: 1, required: false })
+  @IsOptional()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
+  playerNumberDire?: number;
+  @ApiProperty({ default: 100, required: false })
+  @IsOptional()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
+  towerPowerPct?: number;
+  /** 复活时间百分比；客户端上线后发送，未传则不参与刷分判断 */
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
+  respawnTimePct?: number;
 }
 
 export class GameEndPlayerDto {
   @ApiProperty({ default: 'npc_dota_hero_abaddon' })
-  @IsString()
-  @IsNotEmpty()
   heroName: string;
   @ApiProperty()
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
   steamId: number;
   @ApiProperty()
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
   teamId: number;
   @ApiProperty()
-  @IsBoolean()
   isDisconnected: boolean;
   @ApiProperty()
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
   level: number;
   @ApiProperty()
   @IsNumber({ allowNaN: false, allowInfinity: false })
@@ -78,12 +66,8 @@ export class GameEndPlayerDto {
   @Min(0)
   assists: number;
   @ApiProperty()
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
   score: number;
   @ApiProperty()
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
   battlePoints: number;
 
   @ApiProperty()
@@ -114,12 +98,8 @@ export class GameEndDto extends EventBaseDto {
   @Type(() => GameEndGameOptionsDto)
   gameOptions: GameEndGameOptionsDto;
   @ApiProperty({ default: 2 })
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
   winnerTeamId: number;
   @ApiProperty()
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
   gameTimeMsec: number;
   @ApiProperty({ type: [GameEndPlayerDto], maxLength: 20 })
   @IsArray()
@@ -128,7 +108,5 @@ export class GameEndDto extends EventBaseDto {
   @Type(() => GameEndPlayerDto)
   players: GameEndPlayerDto[];
   @ApiProperty()
-  @IsOptional()
-  @IsString()
   countryCode?: string;
 }

--- a/api/src/analytics/dto/game-end-dto.ts
+++ b/api/src/analytics/dto/game-end-dto.ts
@@ -1,40 +1,22 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsArray, IsNotEmpty, IsNumber, IsOptional, Min, ValidateNested } from 'class-validator';
+import { IsArray, IsNotEmpty, IsNumber, Min, ValidateNested } from 'class-validator';
 
 import { EventBaseDto } from './event-base-dto';
 
 export class GameEndGameOptionsDto {
-  @ApiProperty({ default: 1, required: false })
-  @IsOptional()
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
-  multiplierRadiant?: number;
-  @ApiProperty({ default: 1, required: false })
-  @IsOptional()
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
-  multiplierDire?: number;
-  @ApiProperty({ default: 1, required: false })
-  @IsOptional()
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
-  playerNumberRadiant?: number;
-  @ApiProperty({ default: 1, required: false })
-  @IsOptional()
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
-  playerNumberDire?: number;
-  @ApiProperty({ default: 100, required: false })
-  @IsOptional()
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
-  towerPowerPct?: number;
-  /** 复活时间百分比；客户端上线后发送，未传则不参与刷分判断 */
+  @ApiProperty({ default: 1 })
+  multiplierRadiant: number;
+  @ApiProperty({ default: 1 })
+  multiplierDire: number;
+  @ApiProperty({ default: 1 })
+  playerNumberRadiant: number;
+  @ApiProperty({ default: 1 })
+  playerNumberDire: number;
+  @ApiProperty({ default: 100 })
+  towerPowerPct: number;
+  /** 客户端下一版起发送；未传时不参与刷分判断 */
   @ApiProperty({ required: false })
-  @IsOptional()
-  @IsNumber({ allowNaN: false, allowInfinity: false })
-  @Min(0)
   respawnTimePct?: number;
 }
 
@@ -94,7 +76,6 @@ export class GameEndPlayerDto {
 
 export class GameEndDto extends EventBaseDto {
   @ApiProperty({ type: GameEndGameOptionsDto })
-  @ValidateNested()
   @Type(() => GameEndGameOptionsDto)
   gameOptions: GameEndGameOptionsDto;
   @ApiProperty({ default: 2 })

--- a/api/src/analytics/dto/game-end-dto.ts
+++ b/api/src/analytics/dto/game-end-dto.ts
@@ -1,67 +1,134 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+  ValidateNested,
+} from 'class-validator';
 
 import { EventBaseDto } from './event-base-dto';
 
 export class GameEndGameOptionsDto {
   @ApiProperty({ default: 1 })
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   multiplierRadiant: number;
   @ApiProperty({ default: 1 })
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   multiplierDire: number;
   @ApiProperty({ default: 1 })
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   playerNumberRadiant: number;
   @ApiProperty({ default: 1 })
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   playerNumberDire: number;
   @ApiProperty({ default: 100 })
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   towerPowerPct: number;
+  @ApiProperty({ required: false, default: 100 })
+  @IsOptional()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
+  respawnTime?: number;
 }
 
 export class GameEndPlayerDto {
   @ApiProperty({ default: 'npc_dota_hero_abaddon' })
+  @IsString()
+  @IsNotEmpty()
   heroName: string;
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   steamId: number;
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   teamId: number;
   @ApiProperty()
+  @IsBoolean()
   isDisconnected: boolean;
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   level: number;
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   totalGoldEarned: number;
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   kills: number;
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   deaths: number;
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   assists: number;
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   score: number;
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   battlePoints: number;
 
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   lastHits: number;
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   heroDamage: number;
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   damageTaken: number;
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   healing: number;
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   towerKills: number;
 }
 
 export class GameEndDto extends EventBaseDto {
   @ApiProperty({ type: GameEndGameOptionsDto })
+  @ValidateNested()
+  @Type(() => GameEndGameOptionsDto)
   gameOptions: GameEndGameOptionsDto;
   @ApiProperty({ default: 2 })
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   winnerTeamId: number;
   @ApiProperty()
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  @Min(0)
   gameTimeMsec: number;
   @ApiProperty({ type: [GameEndPlayerDto], maxLength: 20 })
+  @IsArray()
   @IsNotEmpty()
+  @ValidateNested({ each: true })
+  @Type(() => GameEndPlayerDto)
   players: GameEndPlayerDto[];
   @ApiProperty()
+  @IsOptional()
+  @IsString()
   countryCode?: string;
 }

--- a/api/src/game/game.controller.ts
+++ b/api/src/game/game.controller.ts
@@ -132,9 +132,12 @@ export class GameController {
       this.analyticsService.gameEndMatch(gameEnd, serverType),
       this.analyticsService.gameEndPlayerBot(gameEnd, serverType),
       ...(serverType !== SERVER_TYPE.TENVTEN
-        ? players
-            .filter((p) => p.steamId > 0)
-            .map((p) => this.playerStatsLifetimeService.accumulate(p.steamId, p))
+        ? players.map((p) =>
+            this.playerStatsLifetimeService.accumulate(p.steamId, p, {
+              matchId: gameEnd.matchId,
+              gameOptions: gameEnd.gameOptions,
+            }),
+          )
         : []),
     ]);
     return this.gameService.getOK();

--- a/api/src/player/player-stats-lifetime.constants.ts
+++ b/api/src/player/player-stats-lifetime.constants.ts
@@ -1,0 +1,76 @@
+import { GameEndGameOptionsDto } from '../analytics/dto/game-end-dto';
+
+export const STATS_LIFETIME_MAX_RADIANT_MULTIPLIER = 2;
+export const STATS_LIFETIME_MAX_DIRE_MULTIPLIER = 20;
+export const STATS_LIFETIME_MIN_RESPAWN_TIME = 50;
+
+export const PER_MATCH_MAX_KILLS = 1000;
+export const PER_MATCH_MAX_DEATHS = 1000;
+export const PER_MATCH_MAX_ASSISTS = 1000;
+export const PER_MATCH_MAX_LAST_HITS = 10000;
+export const PER_MATCH_MAX_HERO_DAMAGE = 100000000;
+export const PER_MATCH_MAX_DAMAGE_TAKEN = 100000000;
+export const PER_MATCH_MAX_HEALING = 100000000;
+export const PER_MATCH_MAX_TOWER_KILLS = 100;
+export const PER_MATCH_MAX_TOTAL_GOLD_EARNED = 100000000;
+
+export const STATS_LIFETIME_FIELDS = [
+  'kills',
+  'deaths',
+  'assists',
+  'lastHits',
+  'heroDamage',
+  'damageTaken',
+  'healing',
+  'towerKills',
+  'totalGoldEarned',
+] as const;
+
+export type StatsLifetimeField = (typeof STATS_LIFETIME_FIELDS)[number];
+
+const FIELD_MAX_MAP: Record<StatsLifetimeField, number> = {
+  kills: PER_MATCH_MAX_KILLS,
+  deaths: PER_MATCH_MAX_DEATHS,
+  assists: PER_MATCH_MAX_ASSISTS,
+  lastHits: PER_MATCH_MAX_LAST_HITS,
+  heroDamage: PER_MATCH_MAX_HERO_DAMAGE,
+  damageTaken: PER_MATCH_MAX_DAMAGE_TAKEN,
+  healing: PER_MATCH_MAX_HEALING,
+  towerKills: PER_MATCH_MAX_TOWER_KILLS,
+  totalGoldEarned: PER_MATCH_MAX_TOTAL_GOLD_EARNED,
+};
+
+export function shouldSkipStatsLifetimeForGameOptions(options?: GameEndGameOptionsDto): boolean {
+  if (!options) {
+    return false;
+  }
+  if (options.multiplierRadiant > STATS_LIFETIME_MAX_RADIANT_MULTIPLIER) {
+    return true;
+  }
+  if (options.multiplierDire > STATS_LIFETIME_MAX_DIRE_MULTIPLIER) {
+    return true;
+  }
+  if (options.respawnTime !== undefined && options.respawnTime < STATS_LIFETIME_MIN_RESPAWN_TIME) {
+    return true;
+  }
+  return false;
+}
+
+export function toFiniteNumber(value: unknown): number | null {
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue)) {
+    return null;
+  }
+  return numberValue;
+}
+
+export function validateStatContribution(field: StatsLifetimeField, value: unknown): number | null {
+  const numberValue = toFiniteNumber(value);
+  if (numberValue === null || numberValue < 0) {
+    return null;
+  }
+  if (numberValue > FIELD_MAX_MAP[field]) {
+    return null;
+  }
+  return numberValue;
+}

--- a/api/src/player/player-stats-lifetime.constants.ts
+++ b/api/src/player/player-stats-lifetime.constants.ts
@@ -2,7 +2,8 @@ import { GameEndGameOptionsDto } from '../analytics/dto/game-end-dto';
 
 export const STATS_LIFETIME_MAX_RADIANT_MULTIPLIER = 2;
 export const STATS_LIFETIME_MAX_DIRE_MULTIPLIER = 20;
-export const STATS_LIFETIME_MIN_RESPAWN_TIME = 50;
+/** 复活时间百分比低于此值视为刷分配置（与 issue #908 respawn_time < 50 同语义） */
+export const STATS_LIFETIME_MIN_RESPAWN_TIME_PCT = 50;
 
 export const PER_MATCH_MAX_KILLS = 1000;
 export const PER_MATCH_MAX_DEATHS = 1000;
@@ -44,13 +45,22 @@ export function shouldSkipStatsLifetimeForGameOptions(options?: GameEndGameOptio
   if (!options) {
     return false;
   }
-  if (options.multiplierRadiant > STATS_LIFETIME_MAX_RADIANT_MULTIPLIER) {
+  if (
+    options.multiplierRadiant != null &&
+    options.multiplierRadiant > STATS_LIFETIME_MAX_RADIANT_MULTIPLIER
+  ) {
     return true;
   }
-  if (options.multiplierDire > STATS_LIFETIME_MAX_DIRE_MULTIPLIER) {
+  if (
+    options.multiplierDire != null &&
+    options.multiplierDire > STATS_LIFETIME_MAX_DIRE_MULTIPLIER
+  ) {
     return true;
   }
-  if (options.respawnTime !== undefined && options.respawnTime < STATS_LIFETIME_MIN_RESPAWN_TIME) {
+  if (
+    options.respawnTimePct != null &&
+    options.respawnTimePct < STATS_LIFETIME_MIN_RESPAWN_TIME_PCT
+  ) {
     return true;
   }
   return false;

--- a/api/src/player/player-stats-lifetime.service.spec.ts
+++ b/api/src/player/player-stats-lifetime.service.spec.ts
@@ -1,0 +1,181 @@
+import { logger } from 'firebase-functions';
+
+import { GameEndPlayerDto } from '../analytics/dto/game-end-dto';
+
+import { PlayerStatsLifetime } from './entities/player-stats-lifetime.entity';
+import { PlayerStatsLifetimeService } from './player-stats-lifetime.service';
+
+describe('PlayerStatsLifetimeService', () => {
+  const findById = jest.fn();
+  const update = jest.fn();
+  const create = jest.fn();
+  const repository = { findById, update, create };
+  const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+  const basePlayer = (overrides: Partial<GameEndPlayerDto> = {}): GameEndPlayerDto =>
+    ({
+      heroName: 'npc_dota_hero_medusa',
+      steamId: 123,
+      teamId: 2,
+      isDisconnected: false,
+      level: 30,
+      totalGoldEarned: 10000,
+      kills: 5,
+      deaths: 3,
+      assists: 2,
+      score: 10,
+      battlePoints: 100,
+      lastHits: 50,
+      heroDamage: 5000,
+      damageTaken: 1000,
+      healing: 0,
+      towerKills: 1,
+      ...overrides,
+    }) as GameEndPlayerDto;
+
+  beforeEach(() => {
+    findById.mockReset();
+    update.mockReset();
+    create.mockReset();
+    warnSpy.mockClear();
+  });
+
+  afterAll(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('should skip invalid field contribution and keep other fields', async () => {
+    const service = new PlayerStatsLifetimeService(repository as never);
+    findById.mockResolvedValueOnce({
+      id: '123',
+      kills: 10,
+      deaths: 10,
+      assists: 10,
+      lastHits: 10,
+      heroDamage: 2000,
+      damageTaken: 10,
+      healing: 10,
+      towerKills: 10,
+      totalGoldEarned: 10,
+      updatedAt: new Date(),
+    } as PlayerStatsLifetime);
+
+    await service.accumulate(123, basePlayer({ heroDamage: undefined as never }), {
+      matchId: 'm-1',
+      gameOptions: {
+        multiplierRadiant: 1,
+        multiplierDire: 1,
+        playerNumberRadiant: 1,
+        playerNumberDire: 1,
+        towerPowerPct: 100,
+      },
+    });
+
+    expect(update).toHaveBeenCalledTimes(1);
+    const updated = update.mock.calls[0][0] as PlayerStatsLifetime;
+    expect(updated.heroDamage).toBe(2000);
+    expect(updated.kills).toBe(15);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('should heal NaN base value when delta is valid', async () => {
+    const service = new PlayerStatsLifetimeService(repository as never);
+    findById.mockResolvedValueOnce({
+      id: '123',
+      kills: 0,
+      deaths: 0,
+      assists: 0,
+      lastHits: 0,
+      heroDamage: Number.NaN,
+      damageTaken: 0,
+      healing: 0,
+      towerKills: 0,
+      totalGoldEarned: 0,
+      updatedAt: new Date(),
+    } as PlayerStatsLifetime);
+
+    await service.accumulate(123, basePlayer({ heroDamage: 321 }), {
+      matchId: 'm-2',
+      gameOptions: {
+        multiplierRadiant: 1,
+        multiplierDire: 1,
+        playerNumberRadiant: 1,
+        playerNumberDire: 1,
+        towerPowerPct: 100,
+      },
+    });
+
+    const updated = update.mock.calls[0][0] as PlayerStatsLifetime;
+    expect(updated.heroDamage).toBe(321);
+  });
+
+  it('should no-op for bot steamId', async () => {
+    const service = new PlayerStatsLifetimeService(repository as never);
+
+    await service.accumulate(0, basePlayer(), {
+      matchId: 'm-bot',
+      gameOptions: {
+        multiplierRadiant: 1,
+        multiplierDire: 1,
+        playerNumberRadiant: 1,
+        playerNumberDire: 1,
+        towerPowerPct: 100,
+      },
+    });
+
+    expect(findById).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('should skip whole accumulation for custom mode options', async () => {
+    const service = new PlayerStatsLifetimeService(repository as never);
+    findById.mockResolvedValueOnce(null);
+
+    await service.accumulate(123, basePlayer(), {
+      matchId: 'm-3',
+      gameOptions: {
+        multiplierRadiant: 3,
+        multiplierDire: 1,
+        playerNumberRadiant: 1,
+        playerNumberDire: 1,
+        towerPowerPct: 100,
+      },
+    });
+
+    expect(create).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('should skip over max contribution field', async () => {
+    const service = new PlayerStatsLifetimeService(repository as never);
+    findById.mockResolvedValueOnce({
+      id: '123',
+      kills: 1,
+      deaths: 1,
+      assists: 1,
+      lastHits: 1,
+      heroDamage: 1,
+      damageTaken: 1,
+      healing: 1,
+      towerKills: 1,
+      totalGoldEarned: 1,
+      updatedAt: new Date(),
+    } as PlayerStatsLifetime);
+
+    await service.accumulate(123, basePlayer({ totalGoldEarned: 999999999 }), {
+      matchId: 'm-4',
+      gameOptions: {
+        multiplierRadiant: 1,
+        multiplierDire: 1,
+        playerNumberRadiant: 1,
+        playerNumberDire: 1,
+        towerPowerPct: 100,
+      },
+    });
+
+    const updated = update.mock.calls[0][0] as PlayerStatsLifetime;
+    expect(updated.totalGoldEarned).toBe(1);
+    expect(updated.kills).toBe(6);
+  });
+});

--- a/api/src/player/player-stats-lifetime.service.spec.ts
+++ b/api/src/player/player-stats-lifetime.service.spec.ts
@@ -1,6 +1,6 @@
 import { logger } from 'firebase-functions';
 
-import { GameEndPlayerDto } from '../analytics/dto/game-end-dto';
+import { GameEndGameOptionsDto, GameEndPlayerDto } from '../analytics/dto/game-end-dto';
 
 import { PlayerStatsLifetime } from './entities/player-stats-lifetime.entity';
 import { PlayerStatsLifetimeService } from './player-stats-lifetime.service';
@@ -33,6 +33,14 @@ describe('PlayerStatsLifetimeService', () => {
       ...overrides,
     }) as GameEndPlayerDto;
 
+  const defaultGameOptions: GameEndGameOptionsDto = {
+    multiplierRadiant: 1,
+    multiplierDire: 1,
+    playerNumberRadiant: 1,
+    playerNumberDire: 1,
+    towerPowerPct: 100,
+  };
+
   beforeEach(() => {
     findById.mockReset();
     update.mockReset();
@@ -62,13 +70,7 @@ describe('PlayerStatsLifetimeService', () => {
 
     await service.accumulate(123, basePlayer({ heroDamage: undefined as never }), {
       matchId: 'm-1',
-      gameOptions: {
-        multiplierRadiant: 1,
-        multiplierDire: 1,
-        playerNumberRadiant: 1,
-        playerNumberDire: 1,
-        towerPowerPct: 100,
-      },
+      gameOptions: defaultGameOptions,
     });
 
     expect(update).toHaveBeenCalledTimes(1);
@@ -96,13 +98,7 @@ describe('PlayerStatsLifetimeService', () => {
 
     await service.accumulate(123, basePlayer({ heroDamage: 321 }), {
       matchId: 'm-2',
-      gameOptions: {
-        multiplierRadiant: 1,
-        multiplierDire: 1,
-        playerNumberRadiant: 1,
-        playerNumberDire: 1,
-        towerPowerPct: 100,
-      },
+      gameOptions: defaultGameOptions,
     });
 
     const updated = update.mock.calls[0][0] as PlayerStatsLifetime;
@@ -114,13 +110,7 @@ describe('PlayerStatsLifetimeService', () => {
 
     await service.accumulate(0, basePlayer(), {
       matchId: 'm-bot',
-      gameOptions: {
-        multiplierRadiant: 1,
-        multiplierDire: 1,
-        playerNumberRadiant: 1,
-        playerNumberDire: 1,
-        towerPowerPct: 100,
-      },
+      gameOptions: defaultGameOptions,
     });
 
     expect(findById).not.toHaveBeenCalled();
@@ -134,11 +124,7 @@ describe('PlayerStatsLifetimeService', () => {
 
     await service.accumulate(123, basePlayer(), {
       matchId: 'm-respawn',
-      gameOptions: {
-        multiplierRadiant: 1,
-        multiplierDire: 1,
-        respawnTimePct: 30,
-      },
+      gameOptions: { ...defaultGameOptions, respawnTimePct: 30 },
     });
 
     expect(create).not.toHaveBeenCalled();
@@ -151,13 +137,7 @@ describe('PlayerStatsLifetimeService', () => {
 
     await service.accumulate(123, basePlayer(), {
       matchId: 'm-3',
-      gameOptions: {
-        multiplierRadiant: 3,
-        multiplierDire: 1,
-        playerNumberRadiant: 1,
-        playerNumberDire: 1,
-        towerPowerPct: 100,
-      },
+      gameOptions: { ...defaultGameOptions, multiplierRadiant: 3 },
     });
 
     expect(create).not.toHaveBeenCalled();
@@ -182,13 +162,7 @@ describe('PlayerStatsLifetimeService', () => {
 
     await service.accumulate(123, basePlayer({ totalGoldEarned: 999999999 }), {
       matchId: 'm-4',
-      gameOptions: {
-        multiplierRadiant: 1,
-        multiplierDire: 1,
-        playerNumberRadiant: 1,
-        playerNumberDire: 1,
-        towerPowerPct: 100,
-      },
+      gameOptions: defaultGameOptions,
     });
 
     const updated = update.mock.calls[0][0] as PlayerStatsLifetime;

--- a/api/src/player/player-stats-lifetime.service.spec.ts
+++ b/api/src/player/player-stats-lifetime.service.spec.ts
@@ -128,6 +128,23 @@ describe('PlayerStatsLifetimeService', () => {
     expect(update).not.toHaveBeenCalled();
   });
 
+  it('should skip whole accumulation when respawnTimePct is below threshold', async () => {
+    const service = new PlayerStatsLifetimeService(repository as never);
+    findById.mockResolvedValueOnce(null);
+
+    await service.accumulate(123, basePlayer(), {
+      matchId: 'm-respawn',
+      gameOptions: {
+        multiplierRadiant: 1,
+        multiplierDire: 1,
+        respawnTimePct: 30,
+      },
+    });
+
+    expect(create).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it('should skip whole accumulation for custom mode options', async () => {
     const service = new PlayerStatsLifetimeService(repository as never);
     findById.mockResolvedValueOnce(null);

--- a/api/src/player/player-stats-lifetime.service.ts
+++ b/api/src/player/player-stats-lifetime.service.ts
@@ -1,10 +1,18 @@
 import { Injectable } from '@nestjs/common';
+import { logger } from 'firebase-functions';
 import { BaseFirestoreRepository } from 'fireorm';
 import { InjectRepository } from 'nestjs-fireorm';
 
-import { GameEndPlayerDto } from '../analytics/dto/game-end-dto';
+import { GameEndGameOptionsDto, GameEndPlayerDto } from '../analytics/dto/game-end-dto';
 
 import { PlayerStatsLifetime } from './entities/player-stats-lifetime.entity';
+import {
+  STATS_LIFETIME_FIELDS,
+  StatsLifetimeField,
+  shouldSkipStatsLifetimeForGameOptions,
+  toFiniteNumber,
+  validateStatContribution,
+} from './player-stats-lifetime.constants';
 
 @Injectable()
 export class PlayerStatsLifetimeService {
@@ -13,40 +21,92 @@ export class PlayerStatsLifetimeService {
     private readonly repository: BaseFirestoreRepository<PlayerStatsLifetime>,
   ) {}
 
-  async accumulate(steamId: number, player: GameEndPlayerDto): Promise<void> {
+  async accumulate(
+    steamId: number,
+    player: GameEndPlayerDto,
+    context: { matchId: string; gameOptions?: GameEndGameOptionsDto },
+  ): Promise<void> {
+    if (steamId <= 0) {
+      return;
+    }
+
+    if (shouldSkipStatsLifetimeForGameOptions(context.gameOptions)) {
+      logger.warn('game/end: skip statsLifetime by gameOptions', {
+        steamId,
+        matchId: context.matchId,
+        gameOptions: context.gameOptions,
+      });
+      return;
+    }
+
     const id = steamId.toString();
     const existing = await this.repository.findById(id);
 
     if (existing) {
-      existing.kills += player.kills;
-      existing.deaths += player.deaths;
-      existing.assists += player.assists;
-      existing.lastHits += player.lastHits;
-      existing.heroDamage += player.heroDamage;
-      existing.damageTaken += player.damageTaken;
-      existing.healing += player.healing;
-      existing.towerKills += player.towerKills;
-      existing.totalGoldEarned += player.totalGoldEarned;
+      this.applyPlayerStats(existing, player, steamId, context.matchId);
       existing.updatedAt = new Date();
       await this.repository.update(existing);
     } else {
-      await this.repository.create({
+      const created: PlayerStatsLifetime = {
         id,
-        kills: player.kills,
-        deaths: player.deaths,
-        assists: player.assists,
-        lastHits: player.lastHits,
-        heroDamage: player.heroDamage,
-        damageTaken: player.damageTaken,
-        healing: player.healing,
-        towerKills: player.towerKills,
-        totalGoldEarned: player.totalGoldEarned,
+        kills: 0,
+        deaths: 0,
+        assists: 0,
+        lastHits: 0,
+        heroDamage: 0,
+        damageTaken: 0,
+        healing: 0,
+        towerKills: 0,
+        totalGoldEarned: 0,
         updatedAt: new Date(),
-      });
+      };
+      this.applyPlayerStats(created, player, steamId, context.matchId);
+      await this.repository.create(created);
     }
   }
 
   async findBySteamId(steamId: number): Promise<PlayerStatsLifetime | null> {
     return await this.repository.findById(steamId.toString());
+  }
+
+  private applyPlayerStats(
+    stats: PlayerStatsLifetime,
+    player: GameEndPlayerDto,
+    steamId: number,
+    matchId: string,
+  ): void {
+    for (const field of STATS_LIFETIME_FIELDS) {
+      const delta = validateStatContribution(field, player[field]);
+      if (delta === null) {
+        logger.warn('game/end: invalid statsLifetime contribution, skip field', {
+          steamId,
+          matchId,
+          field,
+          rawValue: player[field],
+        });
+        continue;
+      }
+      stats[field] = this.safeAdd(stats[field], delta, field, steamId, matchId);
+    }
+  }
+
+  private safeAdd(
+    current: unknown,
+    delta: number,
+    field: StatsLifetimeField,
+    steamId: number,
+    matchId: string,
+  ): number {
+    const currentValue = toFiniteNumber(current);
+    if (currentValue === null) {
+      logger.warn('game/end: invalid statsLifetime base value, reset to 0', {
+        steamId,
+        matchId,
+        field,
+        rawValue: current,
+      });
+      return delta;
+    }
+    return currentValue + delta;
   }
 }

--- a/api/test/game.e2e-spec.ts
+++ b/api/test/game.e2e-spec.ts
@@ -86,7 +86,14 @@ function createGameEndPayload(options: GameEndPayloadOptions = {}) {
     winnerTeamId: options.winnerTeamId ?? 2,
     players: (options.players ?? []).map(createGameEndPlayer),
     gameTimeMsec: 900000,
-    gameOptions: {},
+    gameOptions: {
+      multiplierRadiant: 1,
+      multiplierDire: 1,
+      playerNumberRadiant: 1,
+      playerNumberDire: 1,
+      towerPowerPct: 100,
+      respawnTime: 100,
+    },
     difficulty: 5,
     steamId: 0,
   };
@@ -745,7 +752,14 @@ describe('PlayerController (e2e)', () => {
           winnerTeamId: 2,
           players: [],
           gameTimeMsec: 900000,
-          gameOptions: {},
+          gameOptions: {
+            multiplierRadiant: 1,
+            multiplierDire: 1,
+            playerNumberRadiant: 1,
+            playerNumberDire: 1,
+            towerPowerPct: 100,
+            respawnTime: 100,
+          },
           difficulty: 5,
           steamId: 0,
         })
@@ -998,6 +1012,53 @@ describe('PlayerController (e2e)', () => {
         .post(gameEndUrl)
         .send(createGameEndPayload({ players: [{ steamId }] }))
         .set({ 'x-api-key': 'tenvten-apikey' });
+
+      const stats = await getPlayerStatsLifetime(app, steamId);
+      expect(stats).toBeNull();
+    });
+
+    it('异常超大字段会被跳过，但其他字段继续累计', async () => {
+      mockDate('2023-12-01T00:00:00.000Z');
+      const steamId = 100003022;
+
+      await post(
+        app,
+        gameEndUrl,
+        createGameEndPayload({
+          players: [{ steamId }],
+        }),
+      );
+
+      await post(app, gameEndUrl, {
+        ...createGameEndPayload({ players: [{ steamId }] }),
+        players: [
+          {
+            ...createGameEndPlayer({ steamId }),
+            heroDamage: 99999999999,
+          },
+        ],
+      });
+
+      const stats = await getPlayerStatsLifetime(app, steamId);
+      expect(stats.heroDamage).toEqual(5000);
+      expect(stats.kills).toEqual(10);
+    });
+
+    it('自定义刷分参数下不统计 statsLifetime', async () => {
+      mockDate('2023-12-01T00:00:00.000Z');
+      const steamId = 100003023;
+
+      await post(app, gameEndUrl, {
+        ...createGameEndPayload({ players: [{ steamId }] }),
+        gameOptions: {
+          multiplierRadiant: 3,
+          multiplierDire: 1,
+          playerNumberRadiant: 1,
+          playerNumberDire: 1,
+          towerPowerPct: 100,
+          respawnTime: 100,
+        },
+      });
 
       const stats = await getPlayerStatsLifetime(app, steamId);
       expect(stats).toBeNull();

--- a/api/test/game.e2e-spec.ts
+++ b/api/test/game.e2e-spec.ts
@@ -79,6 +79,14 @@ interface GameEndPayloadOptions {
   winnerTeamId?: number;
 }
 
+const defaultGameOptions = {
+  multiplierRadiant: 1,
+  multiplierDire: 1,
+  playerNumberRadiant: 1,
+  playerNumberDire: 1,
+  towerPowerPct: 100,
+};
+
 function createGameEndPayload(options: GameEndPayloadOptions = {}) {
   return {
     matchId: '8000000001',
@@ -86,7 +94,7 @@ function createGameEndPayload(options: GameEndPayloadOptions = {}) {
     winnerTeamId: options.winnerTeamId ?? 2,
     players: (options.players ?? []).map(createGameEndPlayer),
     gameTimeMsec: 900000,
-    gameOptions: {},
+    gameOptions: defaultGameOptions,
     difficulty: 5,
     steamId: 0,
   };
@@ -745,7 +753,7 @@ describe('PlayerController (e2e)', () => {
           winnerTeamId: 2,
           players: [],
           gameTimeMsec: 900000,
-          gameOptions: {},
+          gameOptions: defaultGameOptions,
           difficulty: 5,
           steamId: 0,
         })
@@ -1037,8 +1045,8 @@ describe('PlayerController (e2e)', () => {
       await post(app, gameEndUrl, {
         ...createGameEndPayload({ players: [{ steamId }] }),
         gameOptions: {
+          ...defaultGameOptions,
           multiplierRadiant: 3,
-          multiplierDire: 1,
         },
       });
 

--- a/api/test/game.e2e-spec.ts
+++ b/api/test/game.e2e-spec.ts
@@ -86,14 +86,7 @@ function createGameEndPayload(options: GameEndPayloadOptions = {}) {
     winnerTeamId: options.winnerTeamId ?? 2,
     players: (options.players ?? []).map(createGameEndPlayer),
     gameTimeMsec: 900000,
-    gameOptions: {
-      multiplierRadiant: 1,
-      multiplierDire: 1,
-      playerNumberRadiant: 1,
-      playerNumberDire: 1,
-      towerPowerPct: 100,
-      respawnTime: 100,
-    },
+    gameOptions: {},
     difficulty: 5,
     steamId: 0,
   };
@@ -752,14 +745,7 @@ describe('PlayerController (e2e)', () => {
           winnerTeamId: 2,
           players: [],
           gameTimeMsec: 900000,
-          gameOptions: {
-            multiplierRadiant: 1,
-            multiplierDire: 1,
-            playerNumberRadiant: 1,
-            playerNumberDire: 1,
-            towerPowerPct: 100,
-            respawnTime: 100,
-          },
+          gameOptions: {},
           difficulty: 5,
           steamId: 0,
         })
@@ -1053,10 +1039,6 @@ describe('PlayerController (e2e)', () => {
         gameOptions: {
           multiplierRadiant: 3,
           multiplierDire: 1,
-          playerNumberRadiant: 1,
-          playerNumberDire: 1,
-          towerPowerPct: 100,
-          respawnTime: 100,
         },
       });
 


### PR DESCRIPTION
## Summary

- Fix `PlayerStatsLifetime` NaN pollution by skipping invalid per-field contributions (non-finite, negative, or over per-match limits) instead of capping values.
- Skip entire lifetime accumulation for bot `steamId <= 0` and custom farming `gameOptions` (radiant multiplier > 2, dire multiplier > 20, respawn time < 50).
- Add `GameEndDto` numeric validation, `respawnTime` on game options, warn logs with `steamId`/`matchId`/`field`/`rawValue`, and unit/e2e tests.

Closes #908

## Test plan

- [x] `npm run test -- player-stats-lifetime.service.spec.ts`
- [x] `FIRESTORE_EMULATOR_HOST=localhost:8080 npx jest --config ./test/jest-e2e.json game.e2e-spec.ts -t "PlayerStatsLifetime 累计战绩"`
- [x] CI green on PR


Made with [Cursor](https://cursor.com)