### PR TITLE
重做可用积分计算并收紧 game/start 鉴权

### DIFF
--- a/api/src/analytics/analytics.service.ts
+++ b/api/src/analytics/analytics.service.ts
@@ -68,6 +68,17 @@ export class AnalyticsService {
     });
   }
 
+  async playerUseMemberPoint(steamId: number, memberPoint: number, reason: string): Promise<void> {
+    await this.sendEvent(steamId.toString(), {
+      name: 'player_use_member_point',
+      params: {
+        steam_id: steamId,
+        member_point: memberPoint,
+        reason,
+      },
+    });
+  }
+
   async trackPlayerLanguage(dto: PlayerLanguageListDto, serverType: SERVER_TYPE) {
     await Promise.all(
       dto.players.map(async (player) => {

--- a/api/src/game/game.controller.ts
+++ b/api/src/game/game.controller.ts
@@ -19,7 +19,6 @@ import { MembersService } from '../members/members.service';
 import { PlayerStatsLifetimeService } from '../player/player-stats-lifetime.service';
 import { PlayerService } from '../player/player.service';
 import { PlayerInfoService } from '../player-info/player-info.service';
-import { Public } from '../util/auth/public.decorator';
 import { SERVER_TYPE, SecretService } from '../util/secret/secret.service';
 
 import { GameStart } from './dto/game-start.response';
@@ -39,7 +38,6 @@ export class GameController {
     private readonly playerStatsLifetimeService: PlayerStatsLifetimeService,
   ) {}
 
-  @Public()
   @Get('start')
   async start(
     @Query('steamIds', new ParseArrayPipe({ items: Number, separator: ',' }))

--- a/api/src/player-info/assemblers/player-dto.assembler.spec.ts
+++ b/api/src/player-info/assemblers/player-dto.assembler.spec.ts
@@ -25,6 +25,8 @@ function makePlayer(override: Partial<Player>): Player {
     disconnectCount: 0,
     seasonPointTotal: 0,
     memberPointTotal: 0,
+    usedSeasonPoint: 0,
+    usedMemberPoint: 0,
     usedLevel: 0,
     conductPoint: 100,
     commendCount: 0,
@@ -42,11 +44,17 @@ describe('PlayerDtoAssembler', () => {
   });
 
   describe('useableSeasonPoint / useableMemberPoint', () => {
-    it('usedLevel=0: full points available (零头 included)', async () => {
+    it('used point missing: full points available (零头 included)', async () => {
       // seasonLevel=3 (getSeasonTotalPoint(3)=300), 200-point 零头
       // memberLevel=1
       const dto = await assembler.assemblePlayerInfoDto(
-        makePlayer({ seasonPointTotal: 500, memberPointTotal: 100, usedLevel: 0 }),
+        makePlayer({
+          seasonPointTotal: 500,
+          memberPointTotal: 100,
+          usedLevel: 3,
+          usedSeasonPoint: undefined,
+          usedMemberPoint: undefined,
+        }),
         [],
       );
 
@@ -54,53 +62,51 @@ describe('PlayerDtoAssembler', () => {
       expect(dto.useableMemberPoint).toBe(100);
     });
 
-    it('优先勇士分配: usedLevel within seasonLevel uses only season pool', async () => {
-      // seasonLevel=3, usedLevel=2 → usedSeasonLevel=2, usedMemberLevel=0
-      // getSeasonTotalPoint(2) = 100
+    it('usedSeasonPoint reduces only season pool', async () => {
       const dto = await assembler.assemblePlayerInfoDto(
-        makePlayer({ seasonPointTotal: 300, memberPointTotal: 0, usedLevel: 2 }),
+        makePlayer({
+          seasonPointTotal: 300,
+          memberPointTotal: 1000,
+          usedLevel: 2,
+          usedSeasonPoint: 120,
+          usedMemberPoint: 0,
+        }),
         [],
       );
 
-      expect(dto.useableSeasonPoint).toBe(200); // 300 - 100
-      expect(dto.useableMemberPoint).toBe(0); // 0 - getMemberTotalPoint(1)=0
+      expect(dto.useableSeasonPoint).toBe(180);
+      expect(dto.useableMemberPoint).toBe(1000);
     });
 
-    it('usedLevel crosses into member pool', async () => {
-      // seasonLevel=3 (getSeasonTotalPoint(3)=300), memberLevel=3 (getMemberTotalPoint(3)=2050)
-      // usedLevel=5 → usedSeasonLevel=3, usedMemberLevel=2
-      // getMemberTotalPoint(2)=1000
+    it('usedMemberPoint reduces only member pool', async () => {
       const dto = await assembler.assemblePlayerInfoDto(
-        makePlayer({ seasonPointTotal: 300, memberPointTotal: 2050, usedLevel: 5 }),
+        makePlayer({
+          seasonPointTotal: 300,
+          memberPointTotal: 2050,
+          usedLevel: 5,
+          usedSeasonPoint: 0,
+          usedMemberPoint: 450,
+        }),
         [],
       );
 
-      expect(dto.useableSeasonPoint).toBe(0); // 300 - 300
-      expect(dto.useableMemberPoint).toBe(1050); // 2050 - 1000
+      expect(dto.useableSeasonPoint).toBe(300);
+      expect(dto.useableMemberPoint).toBe(1600);
     });
 
-    it('勇士升级波动: useableSeasonPoint decreases, useableMemberPoint increases', async () => {
-      // Before level up: seasonLevel=2 (getSeasonTotalPoint(2)=100), usedLevel=4
-      //   usedSeasonLevel=2, usedMemberLevel=2
-      //   useableSeasonPoint = 200-100 = 100
-      //   useableMemberPoint = 2050-getMemberTotalPoint(2)=2050-1000 = 1050
-      const dtoBefore = await assembler.assemblePlayerInfoDto(
-        makePlayer({ seasonPointTotal: 200, memberPointTotal: 2050, usedLevel: 4 }),
+    it('used point above total clamps available points to 0', async () => {
+      const dto = await assembler.assemblePlayerInfoDto(
+        makePlayer({
+          seasonPointTotal: 200,
+          memberPointTotal: 500,
+          usedSeasonPoint: 300,
+          usedMemberPoint: 600,
+        }),
         [],
       );
-      expect(dtoBefore.useableSeasonPoint).toBe(100);
-      expect(dtoBefore.useableMemberPoint).toBe(1050);
 
-      // After level up: seasonLevel=3 (350 points, getSeasonTotalPoint(3)=300), usedLevel=4
-      //   usedSeasonLevel=3, usedMemberLevel=1 → getMemberTotalPoint(1)=0
-      //   useableSeasonPoint = 350-300 = 50 (decreased)
-      //   useableMemberPoint = 2050-0 = 2050 (increased)
-      const dtoAfter = await assembler.assemblePlayerInfoDto(
-        makePlayer({ seasonPointTotal: 350, memberPointTotal: 2050, usedLevel: 4 }),
-        [],
-      );
-      expect(dtoAfter.useableSeasonPoint).toBe(50);
-      expect(dtoAfter.useableMemberPoint).toBe(2050);
+      expect(dto.useableSeasonPoint).toBe(0);
+      expect(dto.useableMemberPoint).toBe(0);
     });
   });
 });

--- a/api/src/player-info/assemblers/player-dto.assembler.ts
+++ b/api/src/player-info/assemblers/player-dto.assembler.ts
@@ -58,16 +58,19 @@ export class PlayerDtoAssembler {
   }
 
   private calculateLevelData(dto: PlayerInfoDto): void {
-    const seasonLevel = PlayerLevelHelper.getSeasonLevelBuyPoint(dto.seasonPointTotal);
+    const seasonPointTotal = dto.seasonPointTotal ?? 0;
+    const memberPointTotal = dto.memberPointTotal ?? 0;
+
+    const seasonLevel = PlayerLevelHelper.getSeasonLevelBuyPoint(seasonPointTotal);
     dto.seasonLevel = seasonLevel;
     dto.seasonCurrrentLevelPoint =
-      dto.seasonPointTotal - PlayerLevelHelper.getSeasonTotalPoint(seasonLevel);
+      seasonPointTotal - PlayerLevelHelper.getSeasonTotalPoint(seasonLevel);
     dto.seasonNextLevelPoint = PlayerLevelHelper.getSeasonNextLevelPoint(seasonLevel);
 
-    const memberLevel = PlayerLevelHelper.getMemberLevelBuyPoint(dto.memberPointTotal);
+    const memberLevel = PlayerLevelHelper.getMemberLevelBuyPoint(memberPointTotal);
     dto.memberLevel = memberLevel;
     dto.memberCurrentLevelPoint =
-      dto.memberPointTotal - PlayerLevelHelper.getMemberTotalPoint(memberLevel);
+      memberPointTotal - PlayerLevelHelper.getMemberTotalPoint(memberLevel);
     dto.memberNextLevelPoint = PlayerLevelHelper.getMemberNextLevelPoint(memberLevel);
 
     dto.totalLevel = seasonLevel + memberLevel;
@@ -78,13 +81,7 @@ export class PlayerDtoAssembler {
   }
 
   private calculateUseablePoints(dto: PlayerInfoDto): void {
-    const usedLevel = dto.usedLevel ?? 0;
-    const usedSeasonLevel = Math.min(usedLevel, dto.seasonLevel);
-    const usedMemberLevel = usedLevel - usedSeasonLevel;
-
-    dto.useableSeasonPoint =
-      dto.seasonPointTotal - PlayerLevelHelper.getSeasonTotalPoint(usedSeasonLevel);
-    dto.useableMemberPoint =
-      dto.memberPointTotal - PlayerLevelHelper.getMemberTotalPoint(usedMemberLevel);
+    dto.useableSeasonPoint = Math.max(0, (dto.seasonPointTotal ?? 0) - (dto.usedSeasonPoint ?? 0));
+    dto.useableMemberPoint = Math.max(0, (dto.memberPointTotal ?? 0) - (dto.usedMemberPoint ?? 0));
   }
 }

--- a/api/src/player-property/player-property.service.ts
+++ b/api/src/player-property/player-property.service.ts
@@ -120,17 +120,20 @@ export class PlayerPropertyService {
 
     if (useMemberPoint) {
       const cost = RESET_PROPERTY_MEMBER_POINT_COST;
-      if (player.memberPointTotal < cost) {
+      const useableMemberPoint = (player.memberPointTotal ?? 0) - (player.usedMemberPoint ?? 0);
+      if (useableMemberPoint < cost) {
         throw new BadRequestException();
       }
-      await this.playerService.upsertAddPoint(steamId, { memberPointTotal: -cost });
+      await this.playerService.upsertAddPoint(steamId, { usedMemberPoint: cost });
     } else {
-      const seasonLevel = PlayerLevelHelper.getSeasonLevelBuyPoint(player.seasonPointTotal);
+      const seasonPointTotal = player.seasonPointTotal ?? 0;
+      const seasonLevel = PlayerLevelHelper.getSeasonLevelBuyPoint(seasonPointTotal);
       const cost = PlayerLevelHelper.getSeasonNextLevelPoint(seasonLevel);
-      if (player.seasonPointTotal < cost) {
+      const useableSeasonPoint = seasonPointTotal - (player.usedSeasonPoint ?? 0);
+      if (useableSeasonPoint < cost) {
         throw new BadRequestException();
       }
-      await this.playerService.upsertAddPoint(steamId, { seasonPointTotal: -cost });
+      await this.playerService.upsertAddPoint(steamId, { usedSeasonPoint: cost });
     }
 
     await this.deleteBySteamId(steamId);

--- a/api/src/player-property/player-property.service.ts
+++ b/api/src/player-property/player-property.service.ts
@@ -120,20 +120,18 @@ export class PlayerPropertyService {
 
     if (useMemberPoint) {
       const cost = RESET_PROPERTY_MEMBER_POINT_COST;
-      const useableMemberPoint = (player.memberPointTotal ?? 0) - (player.usedMemberPoint ?? 0);
-      if (useableMemberPoint < cost) {
+      if ((player.memberPointTotal ?? 0) < cost) {
         throw new BadRequestException();
       }
-      await this.playerService.upsertAddPoint(steamId, { usedMemberPoint: cost });
+      await this.playerService.upsertAddPoint(steamId, { memberPointTotal: -cost });
     } else {
       const seasonPointTotal = player.seasonPointTotal ?? 0;
       const seasonLevel = PlayerLevelHelper.getSeasonLevelBuyPoint(seasonPointTotal);
       const cost = PlayerLevelHelper.getSeasonNextLevelPoint(seasonLevel);
-      const useableSeasonPoint = seasonPointTotal - (player.usedSeasonPoint ?? 0);
-      if (useableSeasonPoint < cost) {
+      if (seasonPointTotal < cost) {
         throw new BadRequestException();
       }
-      await this.playerService.upsertAddPoint(steamId, { usedSeasonPoint: cost });
+      await this.playerService.upsertAddPoint(steamId, { seasonPointTotal: -cost });
     }
 
     await this.deleteBySteamId(steamId);

--- a/api/src/player/dto/update-player.dto.ts
+++ b/api/src/player/dto/update-player.dto.ts
@@ -3,5 +3,10 @@ import { PartialType, PickType } from '@nestjs/swagger';
 import { Player } from '../entities/player.entity';
 
 export class UpdatePlayerDto extends PartialType(
-  PickType(Player, ['seasonPointTotal', 'memberPointTotal'] as const),
+  PickType(Player, [
+    'seasonPointTotal',
+    'memberPointTotal',
+    'usedSeasonPoint',
+    'usedMemberPoint',
+  ] as const),
 ) {}

--- a/api/src/player/dto/use-player-member-points.dto.ts
+++ b/api/src/player/dto/use-player-member-points.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsNotEmpty, IsNumber, IsString, Min } from 'class-validator';
+
+export class UsePlayerMemberPointsDto {
+  @ApiProperty()
+  @IsNumber()
+  steamId: number;
+
+  @ApiProperty({ minimum: 1 })
+  @IsInt()
+  @Min(1)
+  memberPoint: number;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  reason: string;
+}

--- a/api/src/player/entities/player.entity.ts
+++ b/api/src/player/entities/player.entity.ts
@@ -20,6 +20,14 @@ export class Player {
   @IsOptional()
   @IsNumber()
   memberPointTotal: number;
+  @ApiPropertyOptional({ default: 0 })
+  @IsOptional()
+  @IsNumber()
+  usedSeasonPoint?: number;
+  @ApiPropertyOptional({ default: 0 })
+  @IsOptional()
+  @IsNumber()
+  usedMemberPoint?: number;
   // 已使用等级（property 升级累计消耗的 level 总和）
   @ApiProperty()
   usedLevel: number;

--- a/api/src/player/player.controller.ts
+++ b/api/src/player/player.controller.ts
@@ -5,6 +5,7 @@ import { Public } from '../util/auth/public.decorator';
 
 import { ConductPlayerDto } from './dto/conduct-player.dto';
 import { UpdatePlayerSettingDto } from './dto/update-player-setting.dto';
+import { UsePlayerMemberPointsDto } from './dto/use-player-member-points.dto';
 import { PlayerRanking } from './entities/player-ranking.entity';
 import { PlayerSetting } from './entities/player-setting.entity';
 import { Player } from './entities/player.entity';
@@ -56,5 +57,11 @@ export class PlayerController {
   @ApiOperation({ summary: 'Commend or report another player' })
   async conduct(@Body() dto: ConductPlayerDto): Promise<Player> {
     return this.playerConductService.conduct(dto);
+  }
+
+  @Post('/member-points/use')
+  @ApiOperation({ summary: 'Use available member points' })
+  async useMemberPoint(@Body() dto: UsePlayerMemberPointsDto): Promise<Player> {
+    return this.playerService.useMemberPoint(dto);
   }
 }

--- a/api/src/player/player.service.ts
+++ b/api/src/player/player.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { BaseFirestoreRepository } from 'fireorm';
 import { InjectRepository } from 'nestjs-fireorm';
 
 import { AnalyticsService } from '../analytics/analytics.service';
 
 import { UpdatePlayerDto } from './dto/update-player.dto';
+import { UsePlayerMemberPointsDto } from './dto/use-player-member-points.dto';
 import { Player } from './entities/player.entity';
 import { PlayerConductService } from './player-conduct.service';
 
@@ -87,12 +88,40 @@ export class PlayerService {
     const player = await this.getOrNewPlayerBySteamId(steamId);
 
     if (updatePlayerDto.memberPointTotal) {
-      player.memberPointTotal += updatePlayerDto.memberPointTotal;
+      player.memberPointTotal = (player.memberPointTotal ?? 0) + updatePlayerDto.memberPointTotal;
     }
     if (updatePlayerDto.seasonPointTotal) {
-      player.seasonPointTotal += updatePlayerDto.seasonPointTotal;
+      player.seasonPointTotal = (player.seasonPointTotal ?? 0) + updatePlayerDto.seasonPointTotal;
+    }
+    if (updatePlayerDto.usedMemberPoint) {
+      player.usedMemberPoint = (player.usedMemberPoint ?? 0) + updatePlayerDto.usedMemberPoint;
+    }
+    if (updatePlayerDto.usedSeasonPoint) {
+      player.usedSeasonPoint = (player.usedSeasonPoint ?? 0) + updatePlayerDto.usedSeasonPoint;
     }
     return await this.playerRepository.update(player);
+  }
+
+  async useMemberPoint(dto: UsePlayerMemberPointsDto): Promise<Player> {
+    const memberPoint = Math.trunc(dto.memberPoint);
+    if (memberPoint < 1) {
+      throw new BadRequestException();
+    }
+
+    const player = await this.findBySteamId(dto.steamId);
+    if (!player) {
+      throw new BadRequestException();
+    }
+
+    const useableMemberPoint = (player.memberPointTotal ?? 0) - (player.usedMemberPoint ?? 0);
+    if (useableMemberPoint < memberPoint) {
+      throw new BadRequestException();
+    }
+
+    player.usedMemberPoint = (player.usedMemberPoint ?? 0) + memberPoint;
+    await this.playerRepository.update(player);
+    await this.analyticsService.playerUseMemberPoint(dto.steamId, memberPoint, dto.reason);
+    return player;
   }
 
   // 仅供测试初始化使用，生产代码不应调用；conductPoint 的正常变动走 PlayerConductService。
@@ -149,6 +178,8 @@ export class PlayerService {
       disconnectCount: 0,
       seasonPointTotal: 0,
       memberPointTotal: 0,
+      usedSeasonPoint: 0,
+      usedMemberPoint: 0,
       usedLevel: 0,
       lastMatchTime: null,
       conductPoint: 100,

--- a/api/test/game.e2e-spec.ts
+++ b/api/test/game.e2e-spec.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 
 import { MemberLevel } from '../src/members/entities/members.entity';
 
-import { get, initTest, mockDate, post, restoreDate } from './util/util-http';
+import { get, getTestApiKey, initTest, mockDate, post, restoreDate } from './util/util-http';
 import {
   addPlayerProperty,
   createPlayer,
@@ -16,7 +16,7 @@ const gameEndUrl = '/api/game/end';
 const memberPostUrl = '/api/members/';
 
 function callGameStart(app: INestApplication, steamIds: number[]): request.Test {
-  const apiKey = 'Invalid_NotOnDedicatedServer';
+  const apiKey = getTestApiKey();
   const countryCode = 'CN';
   const headers = {
     'x-api-key': apiKey,
@@ -113,6 +113,14 @@ describe('PlayerController (e2e)', () => {
 
   describe('/api/game/start/ (Get)', () => {
     const matchId = 1;
+    it('未携带 API key 时返回 401', async () => {
+      const result = await request(app.getHttpServer())
+        .get(gameStartUrl)
+        .query({ steamIds: [100000000], matchId });
+
+      expect(result.status).toEqual(401);
+    });
+
     describe('单人开始', () => {
       it('普通玩家 新玩家 首次', async () => {
         mockDate('2023-12-01T00:00:00.000Z');

--- a/api/test/player-info.e2e-spec.ts
+++ b/api/test/player-info.e2e-spec.ts
@@ -480,12 +480,7 @@ describe('PlayerInfoController (e2e)', () => {
             steamId: 200000402,
             useMemberPoint: false,
             before: { seasonPointTotal: 200, memberPointTotal: 0 },
-            after: {
-              seasonPointTotal: 200,
-              memberPointTotal: 0,
-              usedSeasonPoint: 200,
-              usedMemberPoint: 0,
-            },
+            after: { seasonPointTotal: 0, memberPointTotal: 0 },
           },
         ],
         [
@@ -494,12 +489,7 @@ describe('PlayerInfoController (e2e)', () => {
             steamId: 200000403,
             useMemberPoint: false,
             before: { seasonPointTotal: 300, memberPointTotal: 1000 },
-            after: {
-              seasonPointTotal: 300,
-              memberPointTotal: 1000,
-              usedSeasonPoint: 300,
-              usedMemberPoint: 0,
-            },
+            after: { seasonPointTotal: 0, memberPointTotal: 1000 },
           },
         ],
         [
@@ -508,12 +498,7 @@ describe('PlayerInfoController (e2e)', () => {
             steamId: 200000412,
             useMemberPoint: true,
             before: { seasonPointTotal: 0, memberPointTotal: 1000 },
-            after: {
-              seasonPointTotal: 0,
-              memberPointTotal: 1000,
-              usedSeasonPoint: 0,
-              usedMemberPoint: 1000,
-            },
+            after: { seasonPointTotal: 0, memberPointTotal: 0 },
           },
         ],
         [
@@ -522,12 +507,7 @@ describe('PlayerInfoController (e2e)', () => {
             steamId: 200000413,
             useMemberPoint: true,
             before: { seasonPointTotal: 999, memberPointTotal: 2000 },
-            after: {
-              seasonPointTotal: 999,
-              memberPointTotal: 2000,
-              usedSeasonPoint: 0,
-              usedMemberPoint: 1000,
-            },
+            after: { seasonPointTotal: 999, memberPointTotal: 1000 },
           },
         ],
       ])('%s', async (_, { steamId, useMemberPoint, before, after }) => {
@@ -547,8 +527,8 @@ describe('PlayerInfoController (e2e)', () => {
         const player = result.body;
         expect(player?.seasonPointTotal).toEqual(after.seasonPointTotal);
         expect(player?.memberPointTotal).toEqual(after.memberPointTotal);
-        expect(player?.usedSeasonPoint ?? 0).toEqual(after.usedSeasonPoint);
-        expect(player?.usedMemberPoint ?? 0).toEqual(after.usedMemberPoint);
+        expect(player?.usedSeasonPoint ?? 0).toEqual(0);
+        expect(player?.usedMemberPoint ?? 0).toEqual(0);
         expect(player?.properties).toHaveLength(0);
         expect(player?.member).toBeUndefined();
       });

--- a/api/test/player-info.e2e-spec.ts
+++ b/api/test/player-info.e2e-spec.ts
@@ -5,6 +5,7 @@ import { addPlayerProperty, createPlayer, getPlayerDto } from './util/util-playe
 
 const getPlayerInfoUrl = '/api/player';
 const upgradePlayerPropertyUrl = '/api/player/property';
+const useMemberPointUrl = '/api/player/member-points/use';
 
 // 验证 PlayerDto 包含所有计算字段
 function expectPlayerDtoHasComputedFields(playerDto: Record<string, unknown>): void {
@@ -133,6 +134,66 @@ describe('PlayerInfoController (e2e)', () => {
       expect(playerDto.totalLevel).toEqual(4); // 3 + 1 = 4
       expect(playerDto.useableLevel).toEqual(4); // 没有使用任何属性
     });
+
+    describe('可用积分计算', () => {
+      it('新用户没有积分', async () => {
+        const steamId = 200000631;
+        mockDate('2023-12-01T00:00:00.000Z');
+        await createPlayer(app, { steamId, seasonPointTotal: 0, memberPointTotal: 0 });
+
+        const result = await get(app, `${getPlayerInfoUrl}/${steamId}/info`);
+
+        expect(result.status).toEqual(200);
+        expect(result.body.seasonPointTotal).toEqual(0);
+        expect(result.body.useableSeasonPoint).toEqual(0);
+        expect(result.body.memberPointTotal).toEqual(0);
+        expect(result.body.useableMemberPoint).toEqual(0);
+      });
+
+      it('有积分未消耗时可用积分等于总积分，消耗会员积分后相应减少', async () => {
+        const steamId = 200000632;
+        mockDate('2023-12-01T00:00:00.000Z');
+        await createPlayer(app, {
+          steamId,
+          seasonPointTotal: 500,
+          memberPointTotal: 100,
+        });
+
+        const beforeResult = await get(app, `${getPlayerInfoUrl}/${steamId}/info`);
+        expect(beforeResult.status).toEqual(200);
+        expect(beforeResult.body.seasonPointTotal).toEqual(500);
+        expect(beforeResult.body.useableSeasonPoint).toEqual(500);
+        expect(beforeResult.body.memberPointTotal).toEqual(100);
+        expect(beforeResult.body.useableMemberPoint).toEqual(100);
+
+        const useResult = await post(app, useMemberPointUrl, {
+          steamId,
+          memberPoint: 25,
+          reason: 'e2e-test',
+        });
+        expect(useResult.status).toEqual(201);
+
+        const afterResult = await get(app, `${getPlayerInfoUrl}/${steamId}/info`);
+        expect(afterResult.status).toEqual(200);
+        expect(afterResult.body.memberPointTotal).toEqual(100);
+        expect(afterResult.body.usedMemberPoint).toEqual(25);
+        expect(afterResult.body.useableMemberPoint).toEqual(75);
+        expect(afterResult.body.useableSeasonPoint).toEqual(500);
+      });
+
+      it('消耗会员积分必须至少为 1', async () => {
+        const steamId = 200000633;
+        await createPlayer(app, { steamId, memberPointTotal: 100 });
+
+        const result = await post(app, useMemberPointUrl, {
+          steamId,
+          memberPoint: 0,
+          reason: 'e2e-test',
+        });
+
+        expect(result.status).toEqual(400);
+      });
+    });
   });
 
   describe('PUT /api/player/property 升级玩家属性', () => {
@@ -259,46 +320,44 @@ describe('PlayerInfoController (e2e)', () => {
             totalLevel: 3,
             useableLevel: 0,
             propertyLevel: 3,
-            useableSeasonPoint: 0,
+            useableSeasonPoint: 100,
             useableMemberPoint: 0,
           },
         },
       ],
       [
-        'useableSeasonPoint 减少（season 部分消耗）',
+        '属性升级不影响 useableSeasonPoint',
         {
           steamId: 200000621,
           seasonPointTotal: 300,
           memberPointTotal: 0,
           level: 2,
-          // usedSeasonLevel=2, getSeasonTotalPoint(2)=100 → 300-100=200
           expected: {
             seasonLevel: 3,
             memberLevel: 1,
             totalLevel: 4,
             useableLevel: 2,
             propertyLevel: 2,
-            useableSeasonPoint: 200,
+            useableSeasonPoint: 300,
             useableMemberPoint: 0,
           },
         },
       ],
       [
-        'season 用尽后 useableMemberPoint 减少',
+        '属性升级不影响 useableMemberPoint',
         {
           steamId: 200000622,
           seasonPointTotal: 300,
           memberPointTotal: 2050,
           level: 5,
-          // usedSeasonLevel=3, usedMemberLevel=2, getMemberTotalPoint(2)=1000 → 2050-1000=1050
           expected: {
             seasonLevel: 3,
             memberLevel: 3,
             totalLevel: 6,
             useableLevel: 1,
             propertyLevel: 5,
-            useableSeasonPoint: 0,
-            useableMemberPoint: 1050,
+            useableSeasonPoint: 300,
+            useableMemberPoint: 2050,
           },
         },
       ],
@@ -421,7 +480,12 @@ describe('PlayerInfoController (e2e)', () => {
             steamId: 200000402,
             useMemberPoint: false,
             before: { seasonPointTotal: 200, memberPointTotal: 0 },
-            after: { seasonPointTotal: 0, memberPointTotal: 0 },
+            after: {
+              seasonPointTotal: 200,
+              memberPointTotal: 0,
+              usedSeasonPoint: 200,
+              usedMemberPoint: 0,
+            },
           },
         ],
         [
@@ -430,7 +494,12 @@ describe('PlayerInfoController (e2e)', () => {
             steamId: 200000403,
             useMemberPoint: false,
             before: { seasonPointTotal: 300, memberPointTotal: 1000 },
-            after: { seasonPointTotal: 0, memberPointTotal: 1000 },
+            after: {
+              seasonPointTotal: 300,
+              memberPointTotal: 1000,
+              usedSeasonPoint: 300,
+              usedMemberPoint: 0,
+            },
           },
         ],
         [
@@ -439,7 +508,12 @@ describe('PlayerInfoController (e2e)', () => {
             steamId: 200000412,
             useMemberPoint: true,
             before: { seasonPointTotal: 0, memberPointTotal: 1000 },
-            after: { seasonPointTotal: 0, memberPointTotal: 0 },
+            after: {
+              seasonPointTotal: 0,
+              memberPointTotal: 1000,
+              usedSeasonPoint: 0,
+              usedMemberPoint: 1000,
+            },
           },
         ],
         [
@@ -448,7 +522,12 @@ describe('PlayerInfoController (e2e)', () => {
             steamId: 200000413,
             useMemberPoint: true,
             before: { seasonPointTotal: 999, memberPointTotal: 2000 },
-            after: { seasonPointTotal: 999, memberPointTotal: 1000 },
+            after: {
+              seasonPointTotal: 999,
+              memberPointTotal: 2000,
+              usedSeasonPoint: 0,
+              usedMemberPoint: 1000,
+            },
           },
         ],
       ])('%s', async (_, { steamId, useMemberPoint, before, after }) => {
@@ -468,6 +547,8 @@ describe('PlayerInfoController (e2e)', () => {
         const player = result.body;
         expect(player?.seasonPointTotal).toEqual(after.seasonPointTotal);
         expect(player?.memberPointTotal).toEqual(after.memberPointTotal);
+        expect(player?.usedSeasonPoint ?? 0).toEqual(after.usedSeasonPoint);
+        expect(player?.usedMemberPoint ?? 0).toEqual(after.usedMemberPoint);
         expect(player?.properties).toHaveLength(0);
         expect(player?.member).toBeUndefined();
       });

--- a/api/test/util/util-http.ts
+++ b/api/test/util/util-http.ts
@@ -15,9 +15,18 @@ export async function initTest(): Promise<INestApplication> {
   return await app.init();
 }
 
+export function getTestApiKey(): string {
+  return (
+    process.env.SERVER_APIKEY_TEST ??
+    process.env.SERVER_APIKEY ??
+    process.env.SERVER_APIKEY_TENVTEN ??
+    'Invalid_NotOnDedicatedServer'
+  );
+}
+
 export function get(app: INestApplication, url: string, query: object = {}): request.Test {
   const headers = {
-    'x-api-key': 'Invalid_NotOnDedicatedServer',
+    'x-api-key': getTestApiKey(),
     'x-country-code': 'CN',
   };
   return request(app.getHttpServer()).get(url).query(query).set(headers);
@@ -25,28 +34,28 @@ export function get(app: INestApplication, url: string, query: object = {}): req
 
 export function post(app: INestApplication, url: string, body: object): request.Test {
   const headers = {
-    'x-api-key': 'Invalid_NotOnDedicatedServer',
+    'x-api-key': getTestApiKey(),
   };
   return request(app.getHttpServer()).post(url).send(body).set(headers);
 }
 
 export function put(app: INestApplication, url: string, body: object): request.Test {
   const headers = {
-    'x-api-key': 'Invalid_NotOnDedicatedServer',
+    'x-api-key': getTestApiKey(),
   };
   return request(app.getHttpServer()).put(url).send(body).set(headers);
 }
 
 export function patch(app: INestApplication, url: string, body: object): request.Test {
   const headers = {
-    'x-api-key': 'Invalid_NotOnDedicatedServer',
+    'x-api-key': getTestApiKey(),
   };
   return request(app.getHttpServer()).patch(url).send(body).set(headers);
 }
 
 export function del(app: INestApplication, url: string, query: object = {}): request.Test {
   const headers = {
-    'x-api-key': 'Invalid_NotOnDedicatedServer',
+    'x-api-key': getTestApiKey(),
   };
   return request(app.getHttpServer()).delete(url).query(query).set(headers);
 }

--- a/extensions/players_schema.json
+++ b/extensions/players_schema.json
@@ -30,6 +30,16 @@
       "column_name": "member_point_total"
     },
     {
+      "name": "usedSeasonPoint",
+      "type": "number",
+      "column_name": "used_season_point"
+    },
+    {
+      "name": "usedMemberPoint",
+      "type": "number",
+      "column_name": "used_member_point"
+    },
+    {
       "name": "conductPoint",
       "type": "number",
       "column_name": "conduct_point"


### PR DESCRIPTION
### Summary
- 将玩家可用积分改为按 `total - used` 计算，新增 `usedSeasonPoint` 和 `usedMemberPoint`，旧数据缺字段时按 `0` 处理
- 新增会员积分消耗接口，要求 `memberPoint >= 1`，并记录 GA 事件 `player_use_member_point`
- `game/start` 不再公开访问，改为需要身份验证
- `reset property` 改为扣减 used 点数而不是直接减少总积分，并同步更新 e2e 覆盖
- 补充 player schema 导出字段，避免下游同步缺列

### Testing
- 已更新并补充相关单元测试与 e2e 测试，覆盖可用积分计算、会员积分消耗和 `game/start` 鉴权
- 格式化已通过
- TypeScript `tsc --noEmit` 已通过