### PR TITLE
让会员积分消耗接口返回 PlayerInfoDto

### DIFF
--- a/api/src/player-info/player-info.controller.ts
+++ b/api/src/player-info/player-info.controller.ts
@@ -7,12 +7,15 @@ import {
   ParseArrayPipe,
   ParseBoolPipe,
   ParseIntPipe,
+  Post,
   Put,
   Query,
 } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 
 import { AnalyticsService } from '../analytics/analytics.service';
+import { UsePlayerMemberPointsDto } from '../player/dto/use-player-member-points.dto';
+import { PlayerService } from '../player/player.service';
 import { PlayerPropertyItemDto } from '../player-property/dto/player-property-item.dto';
 import { ResetPlayerPropertyDto } from '../player-property/dto/reset-player-property.dto';
 import { UpgradePlayerPropertyDto } from '../player-property/dto/upgrade-player-property.dto';
@@ -29,6 +32,7 @@ export class PlayerInfoController {
     private readonly playerInfoService: PlayerInfoService,
     private readonly playerPropertyService: PlayerPropertyService,
     private readonly analyticsService: AnalyticsService,
+    private readonly playerService: PlayerService,
   ) {}
 
   @Get(':steamId/info')
@@ -45,6 +49,13 @@ export class PlayerInfoController {
     include: PlayerInfoInclude[] = [],
   ): Promise<PlayerInfoDto> {
     return this.playerInfoService.findPlayerInfoBySteamId(steamId, include);
+  }
+
+  @Post('/member-points/use')
+  @ApiOperation({ summary: 'Use available member points' })
+  async useMemberPoint(@Body() dto: UsePlayerMemberPointsDto): Promise<PlayerInfoDto> {
+    await this.playerService.useMemberPoint(dto);
+    return this.playerInfoService.findPlayerInfoBySteamId(dto.steamId, []);
   }
 
   @Put(':steamId/property')

--- a/api/src/player/player.controller.ts
+++ b/api/src/player/player.controller.ts
@@ -5,7 +5,6 @@ import { Public } from '../util/auth/public.decorator';
 
 import { ConductPlayerDto } from './dto/conduct-player.dto';
 import { UpdatePlayerSettingDto } from './dto/update-player-setting.dto';
-import { UsePlayerMemberPointsDto } from './dto/use-player-member-points.dto';
 import { PlayerRanking } from './entities/player-ranking.entity';
 import { PlayerSetting } from './entities/player-setting.entity';
 import { Player } from './entities/player.entity';
@@ -57,11 +56,5 @@ export class PlayerController {
   @ApiOperation({ summary: 'Commend or report another player' })
   async conduct(@Body() dto: ConductPlayerDto): Promise<Player> {
     return this.playerConductService.conduct(dto);
-  }
-
-  @Post('/member-points/use')
-  @ApiOperation({ summary: 'Use available member points' })
-  async useMemberPoint(@Body() dto: UsePlayerMemberPointsDto): Promise<Player> {
-    return this.playerService.useMemberPoint(dto);
   }
 }

--- a/api/test/player-info.e2e-spec.ts
+++ b/api/test/player-info.e2e-spec.ts
@@ -172,6 +172,10 @@ describe('PlayerInfoController (e2e)', () => {
           reason: 'e2e-test',
         });
         expect(useResult.status).toEqual(201);
+        expect(useResult.body.memberPointTotal).toEqual(100);
+        expect(useResult.body.usedMemberPoint).toEqual(25);
+        expect(useResult.body.useableMemberPoint).toEqual(75);
+        expect(useResult.body.useableSeasonPoint).toEqual(500);
 
         const afterResult = await get(app, `${getPlayerInfoUrl}/${steamId}/info`);
         expect(afterResult.status).toEqual(200);


### PR DESCRIPTION
## Summary
- 将 `POST /api/player/member-points/use` 挪到 `PlayerInfoController`，接口返回 `PlayerInfoDto`
- 消耗后直接返回最新玩家信息，前端可拿到 `useableMemberPoint` 和 `useableSeasonPoint`
- 移除 `PlayerController` 中的同名接口，避免职责重复
- 补充 e2e 断言，验证消耗会员积分后返回体包含更新后的可用积分

## Testing
- TypeScript 类型检查通过
- e2e 断言已更新，覆盖接口返回 `PlayerInfoDto` 的可用积分字段