### PR TITLE
Generalize point usage analytics

### DIFF
--- a/api/src/analytics/analytics.service.ts
+++ b/api/src/analytics/analytics.service.ts
@@ -68,12 +68,19 @@ export class AnalyticsService {
     });
   }
 
-  async playerUseMemberPoint(steamId: number, memberPoint: number, reason: string): Promise<void> {
+  async playerUsePoint(
+    steamId: number,
+    points: number,
+    useMemberPoint: boolean,
+    reason: string,
+  ): Promise<void> {
     await this.sendEvent(steamId.toString(), {
-      name: 'player_use_member_point',
+      name: 'player_use_point',
       params: {
         steam_id: steamId,
-        member_point: memberPoint,
+        use_member_point: useMemberPoint,
+        point: points,
+        points,
         reason,
       },
     });

--- a/api/src/player-info/player-info.controller.ts
+++ b/api/src/player-info/player-info.controller.ts
@@ -16,7 +16,6 @@ import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { AnalyticsService } from '../analytics/analytics.service';
 import { UsePlayerMemberPointsDto } from '../player/dto/use-player-member-points.dto';
 import { PlayerService } from '../player/player.service';
-import { PlayerPropertyItemDto } from '../player-property/dto/player-property-item.dto';
 import { ResetPlayerPropertyDto } from '../player-property/dto/reset-player-property.dto';
 import { UpgradePlayerPropertyDto } from '../player-property/dto/upgrade-player-property.dto';
 import { PlayerPropertyService } from '../player-property/player-property.service';
@@ -78,14 +77,5 @@ export class PlayerInfoController {
     await this.playerPropertyService.reset(steamId, useMemberPoint);
     await this.analyticsService.playerResetProperty(resetDto);
     return this.playerInfoService.findPlayerInfoBySteamId(steamId, ['property']);
-  }
-
-  /** @deprecated Use PUT /:steamId/property instead */
-  @Put('property')
-  @ApiOperation({ summary: '[Deprecated] Upgrade player property', deprecated: true })
-  async upgradePlayerPropertyDeprecated(
-    @Body() dto: PlayerPropertyItemDto,
-  ): Promise<PlayerInfoDto> {
-    return this.upgradePlayerProperty(dto.steamId, { name: dto.name, level: dto.level });
   }
 }

--- a/api/src/player/player.service.ts
+++ b/api/src/player/player.service.ts
@@ -120,7 +120,7 @@ export class PlayerService {
 
     player.usedMemberPoint = (player.usedMemberPoint ?? 0) + memberPoint;
     await this.playerRepository.update(player);
-    await this.analyticsService.playerUseMemberPoint(dto.steamId, memberPoint, dto.reason);
+    await this.analyticsService.playerUsePoint(dto.steamId, memberPoint, true, dto.reason);
     return player;
   }
 

--- a/api/test/player-info.e2e-spec.ts
+++ b/api/test/player-info.e2e-spec.ts
@@ -4,7 +4,7 @@ import { del, get, initTest, mockDate, post, put, restoreDate } from './util/uti
 import { addPlayerProperty, createPlayer, getPlayerDto } from './util/util-player';
 
 const getPlayerInfoUrl = '/api/player';
-const upgradePlayerPropertyUrl = '/api/player/property';
+const upgradePlayerPropertyUrl = (steamId: number) => `/api/player/${steamId}/property`;
 const useMemberPointUrl = '/api/player/member-points/use';
 
 // 验证 PlayerDto 包含所有计算字段
@@ -200,7 +200,7 @@ describe('PlayerInfoController (e2e)', () => {
     });
   });
 
-  describe('PUT /api/player/property 升级玩家属性', () => {
+  describe('PUT /api/player/:steamId/property 升级玩家属性', () => {
     beforeEach(() => {
       mockDate('2023-12-01T00:00:00.000Z');
     });
@@ -215,8 +215,7 @@ describe('PlayerInfoController (e2e)', () => {
       });
 
       // 添加属性
-      const result = await put(app, upgradePlayerPropertyUrl, {
-        steamId,
+      const result = await put(app, upgradePlayerPropertyUrl(steamId), {
         name: 'property_cooldown_percentage',
         level: 2,
       });
@@ -246,15 +245,13 @@ describe('PlayerInfoController (e2e)', () => {
       });
 
       // 添加第一个属性
-      await put(app, upgradePlayerPropertyUrl, {
-        steamId,
+      await put(app, upgradePlayerPropertyUrl(steamId), {
         name: 'property_cooldown_percentage',
         level: 1,
       });
 
       // 添加第二个属性
-      const result = await put(app, upgradePlayerPropertyUrl, {
-        steamId,
+      const result = await put(app, upgradePlayerPropertyUrl(steamId), {
         name: 'property_attackspeed_bonus_constant',
         level: 2,
       });
@@ -273,15 +270,13 @@ describe('PlayerInfoController (e2e)', () => {
       });
 
       // 第一次添加属性
-      await put(app, upgradePlayerPropertyUrl, {
-        steamId,
+      await put(app, upgradePlayerPropertyUrl(steamId), {
         name: 'property_cooldown_percentage',
         level: 2,
       });
 
       // 第二次升级同一属性
-      const result = await put(app, upgradePlayerPropertyUrl, {
-        steamId,
+      const result = await put(app, upgradePlayerPropertyUrl(steamId), {
         name: 'property_cooldown_percentage',
         level: 3,
       });
@@ -368,8 +363,7 @@ describe('PlayerInfoController (e2e)', () => {
     ])('%s', async (_, { steamId, seasonPointTotal, memberPointTotal, level, expected }) => {
       await createPlayer(app, { steamId, seasonPointTotal, memberPointTotal });
 
-      const result = await put(app, upgradePlayerPropertyUrl, {
-        steamId,
+      const result = await put(app, upgradePlayerPropertyUrl(steamId), {
         name: 'property_cooldown_percentage',
         level,
       });
@@ -399,8 +393,7 @@ describe('PlayerInfoController (e2e)', () => {
       });
 
       // 第一次添加属性 level = 1
-      const firstResult = await put(app, upgradePlayerPropertyUrl, {
-        steamId,
+      const firstResult = await put(app, upgradePlayerPropertyUrl(steamId), {
         name: 'property_cooldown_percentage',
         level: 1,
       });
@@ -411,8 +404,7 @@ describe('PlayerInfoController (e2e)', () => {
       expect(firstPlayerDto.useableLevel).toEqual(2); // 3 - 1 = 2
 
       // 第二次添加同一属性到 level = 3，刚好用尽剩余点数
-      const secondResult = await put(app, upgradePlayerPropertyUrl, {
-        steamId,
+      const secondResult = await put(app, upgradePlayerPropertyUrl(steamId), {
         name: 'property_cooldown_percentage',
         level: 3, // 从 level 1 升级到 level 3，增加 2 点，刚好用尽
       });
@@ -453,8 +445,7 @@ describe('PlayerInfoController (e2e)', () => {
 
       // 执行前置操作（如果有）
       for (const prop of setupProperties) {
-        const firstResult = await put(app, upgradePlayerPropertyUrl, {
-          steamId,
+        const firstResult = await put(app, upgradePlayerPropertyUrl(steamId), {
           name: prop.name,
           level: prop.level,
         });
@@ -465,8 +456,7 @@ describe('PlayerInfoController (e2e)', () => {
       }
 
       // 尝试添加应该报错的属性
-      const result = await put(app, upgradePlayerPropertyUrl, {
-        steamId,
+      const result = await put(app, upgradePlayerPropertyUrl(steamId), {
         name: errorProperty.name,
         level: errorProperty.level,
       });

--- a/api/test/util/util-player.ts
+++ b/api/test/util/util-player.ts
@@ -61,8 +61,7 @@ export async function addPlayerProperty(
   property: string,
   value: number,
 ): Promise<void> {
-  const result = await put(app, `/api/player/property`, {
-    steamId,
+  const result = await put(app, `/api/player/${steamId}/property`, {
     name: property,
     level: value,
   });


### PR DESCRIPTION
## Summary
- rename the member point GA event to the generic player_use_point event
- send use_member_point plus point/points params for point usage analytics
- remove the deprecated PUT /api/player/property endpoint and update tests/helpers to use PUT /api/player/:steamId/property

## Verification
- npm run tsc equivalent: ./node_modules/.bin/tsc --noEmit -p tsconfig.json
- git diff --check