### PR TITLE
Keep game start public

### DIFF
--- a/api/src/game/game.controller.ts
+++ b/api/src/game/game.controller.ts
@@ -19,6 +19,7 @@ import { MembersService } from '../members/members.service';
 import { PlayerStatsLifetimeService } from '../player/player-stats-lifetime.service';
 import { PlayerService } from '../player/player.service';
 import { PlayerInfoService } from '../player-info/player-info.service';
+import { Public } from '../util/auth/public.decorator';
 import { SERVER_TYPE, SecretService } from '../util/secret/secret.service';
 
 import { GameStart } from './dto/game-start.response';
@@ -38,6 +39,7 @@ export class GameController {
     private readonly playerStatsLifetimeService: PlayerStatsLifetimeService,
   ) {}
 
+  @Public()
   @Get('start')
   async start(
     @Query('steamIds', new ParseArrayPipe({ items: Number, separator: ',' }))

--- a/api/test/game.e2e-spec.ts
+++ b/api/test/game.e2e-spec.ts
@@ -113,12 +113,13 @@ describe('PlayerController (e2e)', () => {
 
   describe('/api/game/start/ (Get)', () => {
     const matchId = 1;
-    it('未携带 API key 时返回 401', async () => {
+    it('未携带 API key 时允许开始游戏', async () => {
+      mockDate('2023-12-01T00:00:00.000Z');
       const result = await request(app.getHttpServer())
         .get(gameStartUrl)
         .query({ steamIds: [100000000], matchId });
 
-      expect(result.status).toEqual(401);
+      expect(result.status).toEqual(200);
     });
 
     describe('单人开始', () => {

--- a/api/test/game.e2e-spec.ts
+++ b/api/test/game.e2e-spec.ts
@@ -454,7 +454,7 @@ describe('PlayerController (e2e)', () => {
 
       it('steamIds刚好10个应正常返回', async () => {
         mockDate('2023-12-01T00:00:00.000Z');
-        const steamIds = Array.from({ length: 10 }, (_, i) => 200000101 + i);
+        const steamIds = Array.from({ length: 10 }, (_, i) => 100004001 + i);
 
         const result = await callGameStart(app, steamIds);
         expect(result.status).toEqual(200);


### PR DESCRIPTION
## Summary
- restore @Public() on GET /api/game/start
- update game start e2e expectation so requests without x-api-key are allowed

## Verification
- ./node_modules/.bin/tsc --noEmit -p tsconfig.json
- git diff --check