### PR TITLE
fix(analytics): correct Alipay GA purchase item price to unit price

### DIFF
--- a/api/src/analytics/analytics.purchase.service.ts
+++ b/api/src/analytics/analytics.purchase.service.ts
@@ -117,7 +117,8 @@ export class AnalyticsPurchaseService {
   }
 
   async alipayPurchase(order: AlipayOrder) {
-    const price = order.totalAmountCent / 100;
+    const totalAmount = order.totalAmountCent / 100;
+    const unitPrice = totalAmount / order.quantity;
 
     const event: PurchaseEvent = {
       name: 'purchase',
@@ -127,7 +128,7 @@ export class AnalyticsPurchaseService {
             item_id: order.productCode,
             item_name: `alipay-${order.productCode}`,
             affiliation: 'alipay',
-            price,
+            price: unitPrice,
             currency: 'CNY',
             quantity: order.quantity,
           },
@@ -135,7 +136,7 @@ export class AnalyticsPurchaseService {
         affiliation: 'alipay',
         currency: 'CNY',
         transaction_id: order.outTradeNo,
-        value: price,
+        value: totalAmount,
       },
     };
 


### PR DESCRIPTION
## Summary

- GA4 calculates item revenue as `price × quantity`
- 之前 `price` 传的是**总金额**（已含所有月份），`quantity` 又传了月数，导致 GA 报告金额被放大 N 倍（如买 12 个月 = 12×）
- 修复：`price` 改为**单价**（`totalAmount / quantity`），`value` 保持为正确的总金额

## Root Cause

```ts
// Before (wrong): price=120, quantity=12 → GA calculates 120×12=1440
const price = order.totalAmountCent / 100;  // total amount
price: price,
quantity: order.quantity,
value: price,

// After (correct): price=10, quantity=12 → GA calculates 10×12=120
const totalAmount = order.totalAmountCent / 100;
const unitPrice = totalAmount / order.quantity;
price: unitPrice,
quantity: order.quantity,
value: totalAmount,
```

## Test plan

- [ ] 购买单月会员：GA 金额 = 单月价格 × 1
- [ ] 购买 12 个月会员：GA 金额 = 单月价格 × 12 = 总金额（不再是 144×）

https://claude.ai/code/session_01B5BAeDNZArRRaT1cie36ck

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5BAeDNZArRRaT1cie36ck)_