### PR TITLE
fix(auth): remove tenvten API key authorization

### DIFF
--- a/api/src/game/game.controller.ts
+++ b/api/src/game/game.controller.ts
@@ -20,7 +20,7 @@ import { PlayerStatsLifetimeService } from '../player/player-stats-lifetime.serv
 import { PlayerService } from '../player/player.service';
 import { PlayerInfoService } from '../player-info/player-info.service';
 import { Public } from '../util/auth/public.decorator';
-import { SERVER_TYPE, SecretService } from '../util/secret/secret.service';
+import { SecretService } from '../util/secret/secret.service';
 
 import { GameStart } from './dto/game-start.response';
 import { PointInfoDto } from './dto/point-info.dto';
@@ -131,14 +131,12 @@ export class GameController {
     await Promise.all([
       this.analyticsService.gameEndMatch(gameEnd, serverType),
       this.analyticsService.gameEndPlayerBot(gameEnd, serverType),
-      ...(serverType !== SERVER_TYPE.TENVTEN
-        ? players.map((p) =>
-            this.playerStatsLifetimeService.accumulate(p.steamId, p, {
-              matchId: gameEnd.matchId,
-              gameOptions: gameEnd.gameOptions,
-            }),
-          )
-        : []),
+      ...players.map((p) =>
+        this.playerStatsLifetimeService.accumulate(p.steamId, p, {
+          matchId: gameEnd.matchId,
+          gameOptions: gameEnd.gameOptions,
+        }),
+      ),
     ]);
     return this.gameService.getOK();
   }

--- a/api/src/game/game.service.spec.ts
+++ b/api/src/game/game.service.spec.ts
@@ -104,15 +104,11 @@ describe('GameService', () => {
       expect(secretService.getSecretValue).toHaveBeenCalledWith(SECRET.GA4_API_SECRET);
     });
 
-    it('should return GA4 config for TENVTEN server', () => {
+    it('should return undefined for TENVTEN server', () => {
       const result = service.getGA4Config(SERVER_TYPE.TENVTEN);
 
-      expect(result).toEqual({
-        measurementId: mockMeasurementId,
-        apiSecret: mockApiSecret,
-        serverType: SERVER_TYPE.TENVTEN,
-      });
-      expect(secretService.getSecretValue).toHaveBeenCalledWith(SECRET.GA4_API_SECRET);
+      expect(result).toBeUndefined();
+      expect(secretService.getSecretValue).not.toHaveBeenCalled();
     });
 
     it('should return undefined for LOCAL server', () => {

--- a/api/src/game/game.service.ts
+++ b/api/src/game/game.service.ts
@@ -102,12 +102,8 @@ export class GameService {
    * @returns GA4配置信息，如果不符合条件则返回undefined
    */
   getGA4Config(serverType: SERVER_TYPE): GA4ConfigDto | undefined {
-    // WINDY、TEST、TENVTEN服务器返回GA4配置信息
-    if (
-      serverType === SERVER_TYPE.WINDY ||
-      serverType === SERVER_TYPE.TEST ||
-      serverType === SERVER_TYPE.TENVTEN
-    ) {
+    // WINDY、TEST服务器返回GA4配置信息
+    if (serverType === SERVER_TYPE.WINDY || serverType === SERVER_TYPE.TEST) {
       const measurementId = process.env.GA_MEASUREMENT_ID;
       const apiSecret = this.secretService.getSecretValue(SECRET.GA4_API_SECRET);
 

--- a/api/src/util/auth/auth.guard.ts
+++ b/api/src/util/auth/auth.guard.ts
@@ -27,9 +27,8 @@ export class AuthGuard implements CanActivate {
 
     const serverApiKey = this.sercretService.getSecretValue(SECRET.SERVER_APIKEY);
     const testServerApiKey = this.sercretService.getSecretValue(SECRET.SERVER_APIKEY_TEST);
-    const tenvtenServerApiKey = this.sercretService.getSecretValue(SECRET.SERVER_APIKEY_TENVTEN);
 
-    if (apiKey === serverApiKey || apiKey === testServerApiKey || apiKey === tenvtenServerApiKey) {
+    if (apiKey === serverApiKey || apiKey === testServerApiKey) {
       return true;
     }
 

--- a/api/test/game.e2e-spec.ts
+++ b/api/test/game.e2e-spec.ts
@@ -750,7 +750,7 @@ describe('PlayerController (e2e)', () => {
   });
 
   describe('Tenvten API Key', () => {
-    it('游戏结算 使用 Tenvten API Key 应该返回 201', async () => {
+    it('游戏结算 使用 Tenvten API Key 应该返回 401', async () => {
       const headers = {
         'x-api-key': 'tenvten-apikey',
       };
@@ -767,7 +767,7 @@ describe('PlayerController (e2e)', () => {
           steamId: 0,
         })
         .set(headers);
-      expect(result.status).toEqual(201);
+      expect(result.status).toEqual(401);
     });
   });
 

--- a/api/test/game.e2e-spec.ts
+++ b/api/test/game.e2e-spec.ts
@@ -1009,17 +1009,6 @@ describe('PlayerController (e2e)', () => {
       expect(stats2.kills).toEqual(5);
     });
 
-    it('使用 Tenvten API Key 不写入 statsLifetime', async () => {
-      const steamId = 100003021;
-      await request(app.getHttpServer())
-        .post(gameEndUrl)
-        .send(createGameEndPayload({ players: [{ steamId }] }))
-        .set({ 'x-api-key': 'tenvten-apikey' });
-
-      const stats = await getPlayerStatsLifetime(app, steamId);
-      expect(stats).toBeNull();
-    });
-
     it('异常超大字段会被跳过，但其他字段继续累计', async () => {
       mockDate('2023-12-01T00:00:00.000Z');
       const steamId = 100003022;

--- a/api/test/util/util-http.ts
+++ b/api/test/util/util-http.ts
@@ -17,10 +17,7 @@ export async function initTest(): Promise<INestApplication> {
 
 export function getTestApiKey(): string {
   return (
-    process.env.SERVER_APIKEY_TEST ??
-    process.env.SERVER_APIKEY ??
-    process.env.SERVER_APIKEY_TENVTEN ??
-    'Invalid_NotOnDedicatedServer'
+    process.env.SERVER_APIKEY_TEST ?? process.env.SERVER_APIKEY ?? 'Invalid_NotOnDedicatedServer'
   );
 }
 


### PR DESCRIPTION
## Summary
- Removed the `SERVER_APIKEY_TENVTEN` branch from `AuthGuard`, so the Tenvten API key is no longer authorized to access the API
- Removed the `serverType !== SERVER_TYPE.TENVTEN` special case in `GameController.end`, so all server types now go through `playerStatsLifetimeService.accumulate`
- Removed `SERVER_APIKEY_TENVTEN` from the test API key fallback chain in `getTestApiKey`
- Updated the e2e test to expect `401` (unauthorized) instead of `201` when using the Tenvten API key

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test:e2e` (game.e2e-spec.ts "Tenvten API Key" should now expect 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)