### PR TITLE
refactor(analytics): rename GA4 param reason to type

### DIFF
--- a/api/src/analytics/analytics.service.ts
+++ b/api/src/analytics/analytics.service.ts
@@ -81,7 +81,7 @@ export class AnalyticsService {
         use_member_point: useMemberPoint,
         point: points,
         points,
-        reason,
+        type: reason,
       },
     });
   }


### PR DESCRIPTION
## 概要

将消耗积分 GA4 event（`player_use_point`）中的 param 名 `reason` 改为 `type`。

## 改动

- `api/src/analytics/analytics.service.ts`：`playerUsePoint` 发送的 GA4 params 中 `reason` → `type: reason`。

## 不变

- API 接口（API IF）保持不变：`playerUsePoint` 方法签名、`UsePlayerMemberPointsDto.reason` 字段、e2e 请求体均未改动。仅修改 GA4 上报的 param 名称。

https://claude.ai/code/session_019Z1YS4cvgjEUFQXrYjh25t

---
_Generated by [Claude Code](https://claude.ai/code/session_019Z1YS4cvgjEUFQXrYjh25t)_