### PR TITLE
PlayerSetting Ward（wardObserverKey/wardSentryKey + QuickCast）

### DIFF
--- a/api/src/player/entities/player-setting.entity.ts
+++ b/api/src/player/entities/player-setting.entity.ts
@@ -25,6 +25,16 @@ export class PlayerSetting {
   @ApiProperty()
   passiveAbilityQuickCast2: boolean;
 
+  // 真假眼改键
+  @ApiProperty({ required: false })
+  wardObserverKey?: string;
+  @ApiProperty({ required: false })
+  wardObserverQuickCast?: boolean;
+  @ApiProperty({ required: false })
+  wardSentryKey?: string;
+  @ApiProperty({ required: false })
+  wardSentryQuickCast?: boolean;
+
   // 为未来其他设置预留
 
   @Exclude()

--- a/api/src/player/player-setting.service.ts
+++ b/api/src/player/player-setting.service.ts
@@ -30,6 +30,12 @@ export class PlayerSettingService {
     if (updatePlayerSettingDto.passiveAbilityQuickCast2 !== undefined) {
       setting.passiveAbilityQuickCast2 = updatePlayerSettingDto.passiveAbilityQuickCast2;
     }
+    if (updatePlayerSettingDto.wardObserverQuickCast !== undefined) {
+      setting.wardObserverQuickCast = updatePlayerSettingDto.wardObserverQuickCast;
+    }
+    if (updatePlayerSettingDto.wardSentryQuickCast !== undefined) {
+      setting.wardSentryQuickCast = updatePlayerSettingDto.wardSentryQuickCast;
+    }
     if (setting.isRememberAbilityKey) {
       if (updatePlayerSettingDto.activeAbilityKey !== undefined) {
         setting.activeAbilityKey = updatePlayerSettingDto.activeAbilityKey;
@@ -40,10 +46,18 @@ export class PlayerSettingService {
       if (updatePlayerSettingDto.passiveAbilityKey2 !== undefined) {
         setting.passiveAbilityKey2 = updatePlayerSettingDto.passiveAbilityKey2;
       }
+      if (updatePlayerSettingDto.wardObserverKey !== undefined) {
+        setting.wardObserverKey = updatePlayerSettingDto.wardObserverKey;
+      }
+      if (updatePlayerSettingDto.wardSentryKey !== undefined) {
+        setting.wardSentryKey = updatePlayerSettingDto.wardSentryKey;
+      }
     } else {
       setting.activeAbilityKey = '';
       setting.passiveAbilityKey = '';
       setting.passiveAbilityKey2 = '';
+      setting.wardObserverKey = '';
+      setting.wardSentryKey = '';
     }
     setting.updatedAt = new Date();
     return this.playerSettingRepository.update(setting);
@@ -68,6 +82,10 @@ export class PlayerSettingService {
       activeAbilityQuickCast: false,
       passiveAbilityQuickCast: false,
       passiveAbilityQuickCast2: false,
+      wardObserverKey: '',
+      wardObserverQuickCast: false,
+      wardSentryKey: '',
+      wardSentryQuickCast: false,
       createdAt: new Date(),
       updatedAt: new Date(),
     };

--- a/api/test/player-setting.e2e-spec.ts
+++ b/api/test/player-setting.e2e-spec.ts
@@ -24,6 +24,10 @@ describe('PlayerSettingController (e2e)', () => {
         activeAbilityQuickCast: false,
         passiveAbilityQuickCast: false,
         passiveAbilityQuickCast2: false,
+        wardObserverKey: '',
+        wardObserverQuickCast: false,
+        wardSentryKey: '',
+        wardSentryQuickCast: false,
         createdAt: expect.any(Date),
         updatedAt: expect.any(Date),
       });
@@ -39,6 +43,10 @@ describe('PlayerSettingController (e2e)', () => {
         activeAbilityQuickCast: true,
         passiveAbilityQuickCast: true,
         passiveAbilityQuickCast2: false,
+        wardObserverKey: 'Y',
+        wardObserverQuickCast: true,
+        wardSentryKey: 'U',
+        wardSentryQuickCast: false,
       };
 
       const response = await put(app, `${playerUrl}/${testPlayer}/setting`, updateData);
@@ -60,6 +68,10 @@ describe('PlayerSettingController (e2e)', () => {
       expect(playerSetting.activeAbilityQuickCast).toEqual(true);
       expect(playerSetting.passiveAbilityQuickCast).toEqual(true);
       expect(playerSetting.passiveAbilityQuickCast2).toEqual(false);
+      expect(playerSetting.wardObserverKey).toEqual('Y');
+      expect(playerSetting.wardObserverQuickCast).toEqual(true);
+      expect(playerSetting.wardSentryKey).toEqual('U');
+      expect(playerSetting.wardSentryQuickCast).toEqual(false);
     });
 
     it('更新玩家设置 - 默认不记住快捷键但保留快速施法', async () => {
@@ -72,6 +84,10 @@ describe('PlayerSettingController (e2e)', () => {
         activeAbilityQuickCast: true,
         passiveAbilityQuickCast: false,
         passiveAbilityQuickCast2: true,
+        wardObserverKey: 'Y',
+        wardObserverQuickCast: true,
+        wardSentryKey: 'U',
+        wardSentryQuickCast: true,
       });
 
       expect(response.status).toEqual(200);
@@ -85,6 +101,10 @@ describe('PlayerSettingController (e2e)', () => {
           activeAbilityQuickCast: true,
           passiveAbilityQuickCast: false,
           passiveAbilityQuickCast2: true,
+          wardObserverKey: '',
+          wardObserverQuickCast: true,
+          wardSentryKey: '',
+          wardSentryQuickCast: true,
         }),
       );
 
@@ -98,6 +118,10 @@ describe('PlayerSettingController (e2e)', () => {
       expect(playerSetting.activeAbilityQuickCast).toEqual(true);
       expect(playerSetting.passiveAbilityQuickCast).toEqual(false);
       expect(playerSetting.passiveAbilityQuickCast2).toEqual(true);
+      expect(playerSetting.wardObserverKey).toEqual('');
+      expect(playerSetting.wardObserverQuickCast).toEqual(true);
+      expect(playerSetting.wardSentryKey).toEqual('');
+      expect(playerSetting.wardSentryQuickCast).toEqual(true);
     });
 
     it('更新玩家设置 - 记忆快捷键后，再取消记忆快捷键但保留快速施法', async () => {
@@ -111,6 +135,10 @@ describe('PlayerSettingController (e2e)', () => {
         activeAbilityQuickCast: true,
         passiveAbilityQuickCast: false,
         passiveAbilityQuickCast2: true,
+        wardObserverKey: 'Y',
+        wardObserverQuickCast: true,
+        wardSentryKey: 'U',
+        wardSentryQuickCast: true,
       });
 
       // 设置不记住快捷键
@@ -130,6 +158,10 @@ describe('PlayerSettingController (e2e)', () => {
           activeAbilityQuickCast: true,
           passiveAbilityQuickCast: false,
           passiveAbilityQuickCast2: true,
+          wardObserverKey: '',
+          wardObserverQuickCast: true,
+          wardSentryKey: '',
+          wardSentryQuickCast: true,
         }),
       );
 
@@ -143,6 +175,10 @@ describe('PlayerSettingController (e2e)', () => {
       expect(playerSetting.activeAbilityQuickCast).toEqual(true);
       expect(playerSetting.passiveAbilityQuickCast).toEqual(false);
       expect(playerSetting.passiveAbilityQuickCast2).toEqual(true);
+      expect(playerSetting.wardObserverKey).toEqual('');
+      expect(playerSetting.wardObserverQuickCast).toEqual(true);
+      expect(playerSetting.wardSentryKey).toEqual('');
+      expect(playerSetting.wardSentryQuickCast).toEqual(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- `PlayerSetting` 新增 4 个 optional 字段：`wardObserverKey`、`wardObserverQuickCast`、`wardSentryKey`、`wardSentryQuickCast`，用于「真假眼额外槛位」自定义改键 + 快速施法
- `PlayerSettingService.update` 按 `passiveAbilityKey2` / `passiveAbilityQuickCast2` 的既有模式处理新字段的写入与默认值（`isRememberAbilityKey` 为 false 时清空 key）
- `createDefaultSettings` 补充新字段的默认值

Closes #944

## Test plan
- [x] `npm run lint` 通过
- [x] `tsc --noEmit` 通过
- [x] `npm run test -- player`：5 个测试套件全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
