### PR TITLE
Add slow immune player property

### DIFF
--- a/api/src/player-property/player-property.service.spec.ts
+++ b/api/src/player-property/player-property.service.spec.ts
@@ -1,6 +1,14 @@
 import { PlayerPropertyService } from './player-property.service';
 
 describe('PlayerPropertyService', () => {
+  describe('validatePropertyName', () => {
+    it('should accept slow immune property', () => {
+      const service = new PlayerPropertyService({} as never, {} as never);
+
+      expect(() => service.validatePropertyName('property_slow_immune')).not.toThrow();
+    });
+  });
+
   describe('calculateUsedLevel', () => {
     it('should return 0 for empty array', () => {
       expect(PlayerPropertyService.calculateUsedLevel([])).toBe(0);

--- a/api/src/player-property/player-property.service.ts
+++ b/api/src/player-property/player-property.service.ts
@@ -45,6 +45,7 @@ export class PlayerPropertyService {
     'property_mana_regen_total_percentage',
     'property_ignore_movespeed_limit',
     'property_cannot_miss',
+    'property_slow_immune',
     'property_flying',
   ];
 


### PR DESCRIPTION
## Summary
- add property_slow_immune to the player property whitelist
- cover validatePropertyName accepting the new property

Fixes #949

## Testing
- Not run locally: Windows/WSL Node/Jest path resolution in this workspace could not resolve ts-jest reliably. Letting PR CI run the suite.