### PR TITLE
洗点改成用 可消耗积分

### DIFF
--- a/api/src/analytics/analytics.service.ts
+++ b/api/src/analytics/analytics.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { logger } from 'firebase-functions/v2';
 
-import { ResetPlayerPropertyDto } from '../player-property/dto/reset-player-property.dto';
 import { SECRET, SERVER_TYPE, SecretService } from '../util/secret/secret.service';
 
 import { PurchaseEvent } from './analytics.purchase.service';
@@ -52,16 +51,6 @@ export class AnalyticsService {
         await this.sendEvent(steamId.toString(), event);
       }),
     );
-  }
-
-  async playerResetProperty(dto: ResetPlayerPropertyDto): Promise<void> {
-    await this.sendEvent(dto.steamId.toString(), {
-      name: 'player_reset_property',
-      params: {
-        steam_id: dto.steamId,
-        use_member_point: dto.useMemberPoint,
-      },
-    });
   }
 
   async playerUsePoint(

--- a/api/src/player-info/player-info.controller.ts
+++ b/api/src/player-info/player-info.controller.ts
@@ -13,10 +13,8 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 
-import { AnalyticsService } from '../analytics/analytics.service';
 import { UsePlayerMemberPointsDto } from '../player/dto/use-player-member-points.dto';
 import { PlayerService } from '../player/player.service';
-import { ResetPlayerPropertyDto } from '../player-property/dto/reset-player-property.dto';
 import { UpgradePlayerPropertyDto } from '../player-property/dto/upgrade-player-property.dto';
 import { PlayerPropertyService } from '../player-property/player-property.service';
 
@@ -30,7 +28,6 @@ export class PlayerInfoController {
   constructor(
     private readonly playerInfoService: PlayerInfoService,
     private readonly playerPropertyService: PlayerPropertyService,
-    private readonly analyticsService: AnalyticsService,
     private readonly playerService: PlayerService,
   ) {}
 
@@ -73,9 +70,7 @@ export class PlayerInfoController {
     @Param('steamId', ParseIntPipe) steamId: number,
     @Query('useMemberPoint', ParseBoolPipe) useMemberPoint: boolean,
   ): Promise<PlayerInfoDto> {
-    const resetDto: ResetPlayerPropertyDto = { steamId, useMemberPoint };
     await this.playerPropertyService.reset(steamId, useMemberPoint);
-    await this.analyticsService.playerResetProperty(resetDto);
     return this.playerInfoService.findPlayerInfoBySteamId(steamId, ['property']);
   }
 }

--- a/api/src/player-property/dto/reset-player-property.dto.ts
+++ b/api/src/player-property/dto/reset-player-property.dto.ts
@@ -1,8 +1,0 @@
-import { ApiProperty } from '@nestjs/swagger';
-
-export class ResetPlayerPropertyDto {
-  @ApiProperty()
-  steamId: number;
-  @ApiProperty()
-  useMemberPoint: boolean;
-}

--- a/api/src/player-property/player-property.module.ts
+++ b/api/src/player-property/player-property.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 import { FireormModule } from 'nestjs-fireorm';
 
+import { AnalyticsModule } from '../analytics/analytics.module';
 import { PlayerModule } from '../player/player.module';
 
 import { PlayerProperty } from './entities/player-property.entity';
 import { PlayerPropertyService } from './player-property.service';
 
 @Module({
-  imports: [FireormModule.forFeature([PlayerProperty]), PlayerModule],
+  imports: [FireormModule.forFeature([PlayerProperty]), PlayerModule, AnalyticsModule],
   controllers: [],
   providers: [PlayerPropertyService],
   exports: [PlayerPropertyService],

--- a/api/src/player-property/player-property.service.spec.ts
+++ b/api/src/player-property/player-property.service.spec.ts
@@ -1,9 +1,11 @@
+import { BadRequestException } from '@nestjs/common';
+
 import { PlayerPropertyService } from './player-property.service';
 
 describe('PlayerPropertyService', () => {
   describe('validatePropertyName', () => {
     it('should accept slow immune property', () => {
-      const service = new PlayerPropertyService({} as never, {} as never);
+      const service = new PlayerPropertyService({} as never, {} as never, {} as never);
 
       expect(() => service.validatePropertyName('property_slow_immune')).not.toThrow();
     });
@@ -35,6 +37,95 @@ describe('PlayerPropertyService', () => {
         { steamId: 123, name: 'property_skill_points_bonus', level: 0 },
       ];
       expect(PlayerPropertyService.calculateUsedLevel(properties)).toBe(5);
+    });
+  });
+
+  describe('reset', () => {
+    const steamId = 123;
+
+    function createService(player: Record<string, number | undefined>) {
+      const playerService = {
+        findBySteamId: jest.fn().mockResolvedValue(player),
+        upsertAddPoint: jest.fn().mockResolvedValue({}),
+        setUsedLevel: jest.fn().mockResolvedValue({}),
+      };
+      const playerPropertyRepository = {
+        delete: jest.fn().mockResolvedValue({}),
+      };
+      const analyticsService = {
+        playerUsePoint: jest.fn().mockResolvedValue(undefined),
+      };
+      const service = new PlayerPropertyService(
+        playerPropertyRepository as never,
+        playerService as never,
+        analyticsService as never,
+      );
+      return { service, playerService, playerPropertyRepository, analyticsService };
+    }
+
+    it('使用会员可用积分重置：扣减 usedMemberPoint，不改变 memberPointTotal', async () => {
+      const { service, playerService, analyticsService } = createService({
+        memberPointTotal: 1000,
+        usedMemberPoint: 0,
+      });
+
+      await service.reset(steamId, true);
+
+      expect(playerService.upsertAddPoint).toHaveBeenCalledWith(steamId, {
+        usedMemberPoint: 1000,
+      });
+      expect(analyticsService.playerUsePoint).toHaveBeenCalledWith(
+        steamId,
+        1000,
+        true,
+        'reset_property',
+      );
+    });
+
+    it('使用会员积分重置：总积分充足但可用积分不足应报错', async () => {
+      const { service, playerService } = createService({
+        memberPointTotal: 1000,
+        usedMemberPoint: 1,
+      });
+
+      await expect(service.reset(steamId, true)).rejects.toThrow(BadRequestException);
+      expect(playerService.upsertAddPoint).not.toHaveBeenCalled();
+    });
+
+    it('使用赛季可用积分重置：扣减 usedSeasonPoint，不改变 seasonPointTotal', async () => {
+      const { service, playerService, analyticsService } = createService({
+        seasonPointTotal: 200,
+        usedSeasonPoint: 0,
+      });
+
+      await service.reset(steamId, false);
+
+      expect(playerService.upsertAddPoint).toHaveBeenCalledWith(steamId, {
+        usedSeasonPoint: 200,
+      });
+      expect(analyticsService.playerUsePoint).toHaveBeenCalledWith(
+        steamId,
+        200,
+        false,
+        'reset_property',
+      );
+    });
+
+    it('使用赛季积分重置：总积分充足但可用积分不足应报错', async () => {
+      const { service, playerService } = createService({
+        seasonPointTotal: 200,
+        usedSeasonPoint: 1,
+      });
+
+      await expect(service.reset(steamId, false)).rejects.toThrow(BadRequestException);
+      expect(playerService.upsertAddPoint).not.toHaveBeenCalled();
+    });
+
+    it('玩家不存在应报错', async () => {
+      const { service, playerService } = createService(null as never);
+      playerService.findBySteamId.mockResolvedValue(null);
+
+      await expect(service.reset(steamId, true)).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/api/src/player-property/player-property.service.ts
+++ b/api/src/player-property/player-property.service.ts
@@ -3,6 +3,7 @@ import { logger } from 'firebase-functions';
 import { BaseFirestoreRepository } from 'fireorm';
 import { InjectRepository } from 'nestjs-fireorm';
 
+import { AnalyticsService } from '../analytics/analytics.service';
 import { PlayerLevelHelper } from '../player/helpers/player-level.helper';
 import { PlayerService } from '../player/player.service';
 
@@ -10,6 +11,7 @@ import { PlayerPropertyItemDto } from './dto/player-property-item.dto';
 import { PlayerProperty } from './entities/player-property.entity';
 
 const RESET_PROPERTY_MEMBER_POINT_COST = 1000;
+const RESET_PROPERTY_REASON = 'reset_property';
 
 @Injectable()
 export class PlayerPropertyService {
@@ -53,6 +55,7 @@ export class PlayerPropertyService {
     @InjectRepository(PlayerProperty)
     private readonly playerPropertyRepository: BaseFirestoreRepository<PlayerProperty>,
     private readonly playerService: PlayerService,
+    private readonly analyticsService: AnalyticsService,
   ) {}
 
   /**
@@ -111,7 +114,8 @@ export class PlayerPropertyService {
 
   /**
    * 重置玩家属性
-   * 消耗赛季积分或会员积分，删除 property 文档，并将 player.usedLevel 重置为 0
+   * 消耗赛季可用积分或会员可用积分（usedSeasonPoint/usedMemberPoint 增加，不影响积分总数和等级），
+   * 删除 property 文档，并将 player.usedLevel 重置为 0
    */
   async reset(steamId: number, useMemberPoint: boolean): Promise<void> {
     const player = await this.playerService.findBySteamId(steamId);
@@ -121,18 +125,22 @@ export class PlayerPropertyService {
 
     if (useMemberPoint) {
       const cost = RESET_PROPERTY_MEMBER_POINT_COST;
-      if ((player.memberPointTotal ?? 0) < cost) {
+      const useableMemberPoint = (player.memberPointTotal ?? 0) - (player.usedMemberPoint ?? 0);
+      if (useableMemberPoint < cost) {
         throw new BadRequestException();
       }
-      await this.playerService.upsertAddPoint(steamId, { memberPointTotal: -cost });
+      await this.playerService.upsertAddPoint(steamId, { usedMemberPoint: cost });
+      await this.analyticsService.playerUsePoint(steamId, cost, true, RESET_PROPERTY_REASON);
     } else {
       const seasonPointTotal = player.seasonPointTotal ?? 0;
       const seasonLevel = PlayerLevelHelper.getSeasonLevelBuyPoint(seasonPointTotal);
       const cost = PlayerLevelHelper.getSeasonNextLevelPoint(seasonLevel);
-      if (seasonPointTotal < cost) {
+      const useableSeasonPoint = seasonPointTotal - (player.usedSeasonPoint ?? 0);
+      if (useableSeasonPoint < cost) {
         throw new BadRequestException();
       }
-      await this.playerService.upsertAddPoint(steamId, { seasonPointTotal: -cost });
+      await this.playerService.upsertAddPoint(steamId, { usedSeasonPoint: cost });
+      await this.analyticsService.playerUsePoint(steamId, cost, false, RESET_PROPERTY_REASON);
     }
 
     await this.deleteBySteamId(steamId);

--- a/api/test/player-info.e2e-spec.ts
+++ b/api/test/player-info.e2e-spec.ts
@@ -484,6 +484,8 @@ describe('PlayerInfoController (e2e)', () => {
               memberPointTotal: 0,
               usedSeasonPoint: 200,
               usedMemberPoint: 0,
+              useableSeasonPoint: 0,
+              useableMemberPoint: 0,
             },
           },
         ],
@@ -503,6 +505,8 @@ describe('PlayerInfoController (e2e)', () => {
               memberPointTotal: 1000,
               usedSeasonPoint: 300,
               usedMemberPoint: 0,
+              useableSeasonPoint: 0,
+              useableMemberPoint: 1000,
             },
           },
         ],
@@ -522,6 +526,8 @@ describe('PlayerInfoController (e2e)', () => {
               memberPointTotal: 1000,
               usedSeasonPoint: 0,
               usedMemberPoint: 1000,
+              useableSeasonPoint: 0,
+              useableMemberPoint: 0,
             },
           },
         ],
@@ -541,6 +547,8 @@ describe('PlayerInfoController (e2e)', () => {
               memberPointTotal: 2000,
               usedSeasonPoint: 0,
               usedMemberPoint: 1500,
+              useableSeasonPoint: 999,
+              useableMemberPoint: 500,
             },
           },
         ],
@@ -565,6 +573,8 @@ describe('PlayerInfoController (e2e)', () => {
         expect(player?.memberPointTotal).toEqual(after.memberPointTotal);
         expect(player?.usedSeasonPoint ?? 0).toEqual(after.usedSeasonPoint);
         expect(player?.usedMemberPoint ?? 0).toEqual(after.usedMemberPoint);
+        expect(player?.useableSeasonPoint).toEqual(after.useableSeasonPoint);
+        expect(player?.useableMemberPoint).toEqual(after.useableMemberPoint);
         expect(player?.properties).toHaveLength(0);
         expect(player?.member).toBeUndefined();
       });
@@ -600,6 +610,8 @@ describe('PlayerInfoController (e2e)', () => {
               memberPointTotal: 0,
               usedSeasonPoint: 1,
               usedMemberPoint: 0,
+              useableSeasonPoint: 199,
+              useableMemberPoint: 0,
             },
           },
         ],
@@ -619,6 +631,8 @@ describe('PlayerInfoController (e2e)', () => {
               memberPointTotal: 1000,
               usedSeasonPoint: 0,
               usedMemberPoint: 1,
+              useableSeasonPoint: 0,
+              useableMemberPoint: 999,
             },
           },
         ],
@@ -643,6 +657,8 @@ describe('PlayerInfoController (e2e)', () => {
         expect(playerDto.memberPointTotal).toEqual(after.memberPointTotal);
         expect(playerDto.usedSeasonPoint ?? 0).toEqual(after.usedSeasonPoint);
         expect(playerDto.usedMemberPoint ?? 0).toEqual(after.usedMemberPoint);
+        expect(playerDto.useableSeasonPoint).toEqual(after.useableSeasonPoint);
+        expect(playerDto.useableMemberPoint).toEqual(after.useableMemberPoint);
         expect(playerDto.properties).toHaveLength(1);
       });
     });

--- a/api/test/player-info.e2e-spec.ts
+++ b/api/test/player-info.e2e-spec.ts
@@ -473,8 +473,18 @@ describe('PlayerInfoController (e2e)', () => {
           {
             steamId: 200000402,
             useMemberPoint: false,
-            before: { seasonPointTotal: 200, memberPointTotal: 0 },
-            after: { seasonPointTotal: 0, memberPointTotal: 0 },
+            before: {
+              seasonPointTotal: 200,
+              memberPointTotal: 0,
+              usedSeasonPoint: 0,
+              usedMemberPoint: 0,
+            },
+            after: {
+              seasonPointTotal: 200,
+              memberPointTotal: 0,
+              usedSeasonPoint: 200,
+              usedMemberPoint: 0,
+            },
           },
         ],
         [
@@ -482,8 +492,18 @@ describe('PlayerInfoController (e2e)', () => {
           {
             steamId: 200000403,
             useMemberPoint: false,
-            before: { seasonPointTotal: 300, memberPointTotal: 1000 },
-            after: { seasonPointTotal: 0, memberPointTotal: 1000 },
+            before: {
+              seasonPointTotal: 300,
+              memberPointTotal: 1000,
+              usedSeasonPoint: 0,
+              usedMemberPoint: 0,
+            },
+            after: {
+              seasonPointTotal: 300,
+              memberPointTotal: 1000,
+              usedSeasonPoint: 300,
+              usedMemberPoint: 0,
+            },
           },
         ],
         [
@@ -491,17 +511,37 @@ describe('PlayerInfoController (e2e)', () => {
           {
             steamId: 200000412,
             useMemberPoint: true,
-            before: { seasonPointTotal: 0, memberPointTotal: 1000 },
-            after: { seasonPointTotal: 0, memberPointTotal: 0 },
+            before: {
+              seasonPointTotal: 0,
+              memberPointTotal: 1000,
+              usedSeasonPoint: 0,
+              usedMemberPoint: 0,
+            },
+            after: {
+              seasonPointTotal: 0,
+              memberPointTotal: 1000,
+              usedSeasonPoint: 0,
+              usedMemberPoint: 1000,
+            },
           },
         ],
         [
-          '使用会员积分，重置',
+          '使用会员积分，重置（总积分充足但已用部分积分）',
           {
             steamId: 200000413,
             useMemberPoint: true,
-            before: { seasonPointTotal: 999, memberPointTotal: 2000 },
-            after: { seasonPointTotal: 999, memberPointTotal: 1000 },
+            before: {
+              seasonPointTotal: 999,
+              memberPointTotal: 2000,
+              usedSeasonPoint: 0,
+              usedMemberPoint: 500,
+            },
+            after: {
+              seasonPointTotal: 999,
+              memberPointTotal: 2000,
+              usedSeasonPoint: 0,
+              usedMemberPoint: 1500,
+            },
           },
         ],
       ])('%s', async (_, { steamId, useMemberPoint, before, after }) => {
@@ -509,6 +549,8 @@ describe('PlayerInfoController (e2e)', () => {
           steamId,
           seasonPointTotal: before.seasonPointTotal,
           memberPointTotal: before.memberPointTotal,
+          usedSeasonPoint: before.usedSeasonPoint,
+          usedMemberPoint: before.usedMemberPoint,
         });
 
         await addPlayerProperty(app, steamId, 'property_cooldown_percentage', 1);
@@ -521,8 +563,8 @@ describe('PlayerInfoController (e2e)', () => {
         const player = result.body;
         expect(player?.seasonPointTotal).toEqual(after.seasonPointTotal);
         expect(player?.memberPointTotal).toEqual(after.memberPointTotal);
-        expect(player?.usedSeasonPoint ?? 0).toEqual(0);
-        expect(player?.usedMemberPoint ?? 0).toEqual(0);
+        expect(player?.usedSeasonPoint ?? 0).toEqual(after.usedSeasonPoint);
+        expect(player?.usedMemberPoint ?? 0).toEqual(after.usedMemberPoint);
         expect(player?.properties).toHaveLength(0);
         expect(player?.member).toBeUndefined();
       });
@@ -540,24 +582,44 @@ describe('PlayerInfoController (e2e)', () => {
         expect(result.status).toEqual(400);
       });
 
-      // 积分不足
+      // 可用积分不足
       it.each([
         [
-          '使用勇士积分，积分不足',
+          '使用勇士积分，总积分充足但可用积分不足',
           {
             steamId: 200000401,
             useMemberPoint: false,
-            before: { seasonPointTotal: 199, memberPointTotal: 0 },
-            after: { seasonPointTotal: 199, memberPointTotal: 0 },
+            before: {
+              seasonPointTotal: 200,
+              memberPointTotal: 0,
+              usedSeasonPoint: 1,
+              usedMemberPoint: 0,
+            },
+            after: {
+              seasonPointTotal: 200,
+              memberPointTotal: 0,
+              usedSeasonPoint: 1,
+              usedMemberPoint: 0,
+            },
           },
         ],
         [
-          '使用会员积分，积分不足',
+          '使用会员积分，总积分充足但可用积分不足',
           {
             steamId: 200000411,
             useMemberPoint: true,
-            before: { seasonPointTotal: 0, memberPointTotal: 999 },
-            after: { seasonPointTotal: 0, memberPointTotal: 999 },
+            before: {
+              seasonPointTotal: 0,
+              memberPointTotal: 1000,
+              usedSeasonPoint: 0,
+              usedMemberPoint: 1,
+            },
+            after: {
+              seasonPointTotal: 0,
+              memberPointTotal: 1000,
+              usedSeasonPoint: 0,
+              usedMemberPoint: 1,
+            },
           },
         ],
       ])('%s', async (_, { steamId, useMemberPoint, before, after }) => {
@@ -565,6 +627,8 @@ describe('PlayerInfoController (e2e)', () => {
           steamId,
           seasonPointTotal: before.seasonPointTotal,
           memberPointTotal: before.memberPointTotal,
+          usedSeasonPoint: before.usedSeasonPoint,
+          usedMemberPoint: before.usedMemberPoint,
         });
 
         await addPlayerProperty(app, steamId, 'property_cooldown_percentage', 1);
@@ -577,6 +641,8 @@ describe('PlayerInfoController (e2e)', () => {
         const playerDto = await getPlayerDto(app, steamId);
         expect(playerDto.seasonPointTotal).toEqual(after.seasonPointTotal);
         expect(playerDto.memberPointTotal).toEqual(after.memberPointTotal);
+        expect(playerDto.usedSeasonPoint ?? 0).toEqual(after.usedSeasonPoint);
+        expect(playerDto.usedMemberPoint ?? 0).toEqual(after.usedMemberPoint);
         expect(playerDto.properties).toHaveLength(1);
       });
     });

--- a/api/test/util/util-player.ts
+++ b/api/test/util/util-player.ts
@@ -17,6 +17,8 @@ interface createPlayerParams {
   steamId: number;
   seasonPointTotal?: number;
   memberPointTotal?: number;
+  usedSeasonPoint?: number;
+  usedMemberPoint?: number;
   conductPoint?: number;
 }
 
@@ -28,6 +30,8 @@ export async function createPlayer(
   await playerService.upsertAddPoint(params.steamId, {
     seasonPointTotal: params.seasonPointTotal,
     memberPointTotal: params.memberPointTotal,
+    usedSeasonPoint: params.usedSeasonPoint,
+    usedMemberPoint: params.usedMemberPoint,
   });
   if (params.conductPoint !== undefined) {
     await playerService.setConductPoint(params.steamId, params.conductPoint);


### PR DESCRIPTION
## Summary
- 重置玩家属性（洗点）现在校验并扣减**可用积分**（`Total - used`），而不是总积分
- 成功后增加 `usedSeasonPoint`/`usedMemberPoint`，不再直接减少 `seasonPointTotal`/`memberPointTotal`，因此不影响玩家赛季/会员等级
- GA 事件由专用的 `player_reset_property` 改为复用已有的 `player_use_point`（`type=reset_property`），与其他积分消耗事件统一，并区分 `use_member_point`
- API 端点（`DELETE /api/player/:steamId/property`，参数 `useMemberPoint`）保持不变
- 移除未使用的 `ResetPlayerPropertyDto` 及 `AnalyticsService.playerResetProperty`

## Issue
- [x] fix #952

## Test plan
- [x] 单元测试：`player-property.service.spec.ts` 新增 `reset()` 测试，覆盖会员/赛季积分的成功重置与“总积分够但可用积分不足”的失败场景
- [x] e2e 测试：`player-info.e2e-spec.ts` 更新断言，验证重置后 `seasonPointTotal`/`memberPointTotal` 不变、`usedSeasonPoint`/`usedMemberPoint` 增加
- [x] `npx jest` 全部通过（128 tests）
- [x] `tsc --noEmit` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)