### PR TITLE
feat(game): add Dragon Boat Festival 2026 event reward

### DIFF
--- a/api/src/event-rewards/entities/event-reward.entity.ts
+++ b/api/src/event-rewards/entities/event-reward.entity.ts
@@ -26,4 +26,5 @@ export class EventReward {
   lunarNewYear2026?: boolean;
   compensation20260301?: boolean; // 补偿活动：1000会员积分+5000赛季积分
   mayDay2026?: boolean; // 51活动：5100会员积分
+  dragonBoat2026?: boolean;
 }

--- a/api/src/event-rewards/event-rewards.service.ts
+++ b/api/src/event-rewards/event-rewards.service.ts
@@ -35,12 +35,12 @@ export class EventRewardsService {
         id,
         steamId,
         // FIXME 活动每次需要更新
-        mayDay2026: true,
+        dragonBoat2026: true,
       });
     } else {
       // update
       // FIXME 活动每次需要更新
-      eventReward.mayDay2026 = true;
+      eventReward.dragonBoat2026 = true;
       await this.eventRewardsRepository.update(eventReward);
     }
   }

--- a/api/src/game/game.controller.ts
+++ b/api/src/game/game.controller.ts
@@ -48,6 +48,7 @@ export class GameController {
     @Req() req: Request,
   ): Promise<GameStart> {
     const apiKey = req.headers['x-api-key'] as string;
+    const serverType = this.secretService.getServerTypeByApiKey(apiKey);
     steamIds = this.gameService.validateSteamIds(steamIds);
 
     const pointInfo: PointInfoDto[] = [];
@@ -56,7 +57,7 @@ export class GameController {
     await Promise.all(steamIds.map((steamId) => this.gameService.upsertPlayerInfo(steamId)));
 
     // 获取活动奖励
-    const eventRewardInfo = await this.gameService.giveEventReward(steamIds);
+    const eventRewardInfo = await this.gameService.giveEventReward(steamIds, serverType);
     pointInfo.push(...eventRewardInfo);
 
     // 获取会员 添加每日会员积分
@@ -68,7 +69,6 @@ export class GameController {
     // ----------------- 以下为统计数据 -----------------
     // 统计数据发送至GA4
     const isLocal = apiKey === 'Invalid_NotOnDedicatedServer';
-    const serverType = this.secretService.getServerTypeByApiKey(apiKey);
     await this.analyticsService.gameStart(steamIds, matchId, isLocal, serverType);
 
     // ----------------- 以下为返回数据 -----------------

--- a/api/src/game/game.service.spec.ts
+++ b/api/src/game/game.service.spec.ts
@@ -13,6 +13,8 @@ import { GameService } from './game.service';
 describe('GameService', () => {
   let service: GameService;
   let secretService: jest.Mocked<SecretService>;
+  let playerService: jest.Mocked<PlayerService>;
+  let eventRewardsService: jest.Mocked<EventRewardsService>;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -33,7 +35,10 @@ describe('GameService', () => {
         },
         {
           provide: EventRewardsService,
-          useValue: {},
+          useValue: {
+            getRewardResults: jest.fn(),
+            setReward: jest.fn(),
+          },
         },
         {
           provide: PlayerPropertyService,
@@ -58,6 +63,8 @@ describe('GameService', () => {
 
     service = moduleRef.get<GameService>(GameService);
     secretService = moduleRef.get(SecretService);
+    playerService = moduleRef.get(PlayerService);
+    eventRewardsService = moduleRef.get(EventRewardsService);
   });
   describe('getOK', () => {
     it('should return OK', () => {
@@ -140,6 +147,69 @@ describe('GameService', () => {
       });
 
       expect(() => service.getGA4Config(SERVER_TYPE.WINDY)).toThrow('Secret not found');
+    });
+  });
+
+  describe('giveEventReward', () => {
+    const steamId = 100000001;
+
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.clearAllMocks();
+    });
+
+    it('windy主机 活动期间内 未领取 应发放端午节积分', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-06-19T00:00:00.000Z'));
+      eventRewardsService.getRewardResults.mockResolvedValue([{ steamId, result: undefined }]);
+
+      const result = await service.giveEventReward([steamId], SERVER_TYPE.WINDY);
+
+      expect(playerService.upsertAddPoint).toHaveBeenCalledWith(steamId, {
+        seasonPointTotal: 5000,
+      });
+      expect(eventRewardsService.setReward).toHaveBeenCalledWith(steamId);
+      expect(result).toEqual([
+        {
+          steamId,
+          title: {
+            cn: '端午节快乐！',
+            en: 'Dragon Boat Festival Bonus!',
+          },
+          seasonPoint: 5000,
+        },
+      ]);
+    });
+
+    it('非windy主机 活动期间内 不应发放', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-06-19T00:00:00.000Z'));
+
+      const result = await service.giveEventReward([steamId], SERVER_TYPE.TEST);
+
+      expect(eventRewardsService.getRewardResults).not.toHaveBeenCalled();
+      expect(playerService.upsertAddPoint).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('windy主机 活动期间外 不应发放', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-06-23T00:00:00.000Z'));
+      eventRewardsService.getRewardResults.mockResolvedValue([{ steamId, result: undefined }]);
+
+      const result = await service.giveEventReward([steamId], SERVER_TYPE.WINDY);
+
+      expect(playerService.upsertAddPoint).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('windy主机 活动期间内 已领取 不应重复发放', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-06-19T00:00:00.000Z'));
+      eventRewardsService.getRewardResults.mockResolvedValue([
+        { steamId, result: { id: steamId.toString(), steamId, dragonBoat2026: true } },
+      ]);
+
+      const result = await service.giveEventReward([steamId], SERVER_TYPE.WINDY);
+
+      expect(playerService.upsertAddPoint).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
     });
   });
 });

--- a/api/src/game/game.service.ts
+++ b/api/src/game/game.service.ts
@@ -64,21 +64,27 @@ export class GameService {
   }
 
   // 活动赠送勇士积分/会员
-  async giveEventReward(steamIds: number[]): Promise<PointInfoDto[]> {
+  async giveEventReward(steamIds: number[], serverType: SERVER_TYPE): Promise<PointInfoDto[]> {
     const pointInfoDtos: PointInfoDto[] = [];
 
-    const startTime = new Date('2026-04-29T00:00:00.000Z');
-    const endTime = new Date('2026-05-10T23:59:59.999Z');
-    const seasonRewardPoint = 5100;
+    // FIXME 活动每次需要更新
+    const startTime = new Date('2026-06-18T00:00:00.000Z');
+    const endTime = new Date('2026-06-22T23:59:59.999Z');
+    const seasonRewardPoint = 5000;
 
     const now = new Date();
+
+    // 仅windy主机参与活动
+    if (serverType !== SERVER_TYPE.WINDY) {
+      return pointInfoDtos;
+    }
 
     // 获取玩家奖励记录
     const rewardResults = await this.eventRewardsService.getRewardResults(steamIds);
 
     for (const rewardResult of rewardResults) {
       // FIXME 活动每次需要更新
-      if (now >= startTime && now <= endTime && !rewardResult.result?.mayDay2026) {
+      if (now >= startTime && now <= endTime && !rewardResult.result?.dragonBoat2026) {
         await this.playerService.upsertAddPoint(rewardResult.steamId, {
           seasonPointTotal: seasonRewardPoint,
         });
@@ -86,8 +92,8 @@ export class GameService {
         pointInfoDtos.push({
           steamId: rewardResult.steamId,
           title: {
-            cn: '五一快乐！',
-            en: 'Happy May Day!',
+            cn: '端午节快乐！',
+            en: 'Dragon Boat Festival Bonus!',
           },
           seasonPoint: seasonRewardPoint,
         });

--- a/api/test/game.e2e-spec.ts
+++ b/api/test/game.e2e-spec.ts
@@ -29,6 +29,21 @@ function callGameStart(app: INestApplication, steamIds: number[]): request.Test 
     .set(headers);
 }
 
+// 使用 windy 主机 API key 发起游戏开始请求
+function callGameStartAsWindyHost(app: INestApplication, steamIds: number[]): request.Test {
+  const apiKey = process.env.SERVER_APIKEY ?? 'Invalid_NotOnDedicatedServer';
+  const countryCode = 'CN';
+  const headers = {
+    'x-api-key': apiKey,
+    'x-country-code': countryCode,
+  };
+
+  return request(app.getHttpServer())
+    .get(gameStartUrl)
+    .query({ steamIds, matchId: 1 })
+    .set(headers);
+}
+
 // 验证 PlayerDto 包含所有计算字段
 function expectPlayerDtoHasComputedFields(playerDto: Record<string, unknown>): void {
   expect(playerDto.seasonLevel).toBeDefined();
@@ -471,12 +486,12 @@ describe('PlayerController (e2e)', () => {
     });
 
     describe('事件奖励', () => {
-      it('活动期间内首次登录 获得活动积分', async () => {
+      it('windy主机 活动期间内首次登录 获得活动积分', async () => {
         const steamId = 100000901;
-        // 活动期间: 2026-04-29 ~ 2026-05-10
-        mockDate('2026-05-01T00:00:00.000Z');
+        // 活动期间: 2026-06-18 ~ 2026-06-22
+        mockDate('2026-06-19T00:00:00.000Z');
 
-        const result = await callGameStart(app, [steamId]);
+        const result = await callGameStartAsWindyHost(app, [steamId]);
         expect(result.status).toEqual(200);
 
         // 验证获得了活动积分
@@ -486,26 +501,26 @@ describe('PlayerController (e2e)', () => {
             p.steamId === steamId && p.seasonPoint,
         );
         expect(eventReward).toBeDefined();
-        expect(eventReward.seasonPoint).toEqual(5100);
+        expect(eventReward.seasonPoint).toEqual(5000);
 
         // 验证玩家积分
         const player = await getPlayer(app, steamId);
-        expect(player.seasonPointTotal).toEqual(5100);
+        expect(player.seasonPointTotal).toEqual(5000);
         expect(player.memberPointTotal).toEqual(0);
       });
 
-      it('活动期间内第二次登录 不重复获得积分', async () => {
+      it('windy主机 活动期间内第二次登录 不重复获得积分', async () => {
         const steamId = 100000902;
-        mockDate('2026-05-01T00:00:00.000Z');
+        mockDate('2026-06-19T00:00:00.000Z');
 
         // 第一次登录
-        await callGameStart(app, [steamId]);
+        await callGameStartAsWindyHost(app, [steamId]);
         const player1 = await getPlayer(app, steamId);
-        expect(player1.seasonPointTotal).toEqual(5100);
+        expect(player1.seasonPointTotal).toEqual(5000);
         expect(player1.memberPointTotal).toEqual(0);
 
         // 第二次登录
-        const result = await callGameStart(app, [steamId]);
+        const result = await callGameStartAsWindyHost(app, [steamId]);
         expect(result.status).toEqual(200);
 
         // 不应该再获得活动积分
@@ -518,14 +533,36 @@ describe('PlayerController (e2e)', () => {
 
         // 积分不变
         const player2 = await getPlayer(app, steamId);
-        expect(player2.seasonPointTotal).toEqual(5100);
+        expect(player2.seasonPointTotal).toEqual(5000);
         expect(player2.memberPointTotal).toEqual(0);
       });
 
-      it('活动期间外 不获得活动积分', async () => {
+      it('windy主机 活动期间外 不获得活动积分', async () => {
         const steamId = 100000903;
         // 活动期间外
-        mockDate('2026-05-11T00:00:00.000Z');
+        mockDate('2026-06-23T00:00:00.000Z');
+
+        const result = await callGameStartAsWindyHost(app, [steamId]);
+        expect(result.status).toEqual(200);
+
+        // 不应该获得活动积分
+        const pointInfo = result.body.pointInfo;
+        const eventReward = pointInfo.find(
+          (p: { steamId: number; seasonPoint?: number; memberPoint?: number }) =>
+            p.steamId === steamId && p.seasonPoint,
+        );
+        expect(eventReward).toBeUndefined();
+
+        // 玩家积分为0
+        const player = await getPlayer(app, steamId);
+        expect(player.seasonPointTotal).toEqual(0);
+        expect(player.memberPointTotal).toEqual(0);
+      });
+
+      it('非windy主机 活动期间内 不获得活动积分', async () => {
+        const steamId = 100000904;
+        // 活动期间内
+        mockDate('2026-06-19T00:00:00.000Z');
 
         const result = await callGameStart(app, [steamId]);
         expect(result.status).toEqual(200);


### PR DESCRIPTION
## Summary
- 新增端午节活动积分奖励：活动期间 2026-06-18T00:00:00.000Z ~ 2026-06-22T23:59:59.999Z（UTC），发放 5000 赛季积分
- 中文文案「端午节快乐！」/ 英文「Dragon Boat Festival Bonus!」

## Test plan
- [x] cd api && npm run test
- [x] cd api && npm run test:e2e
- [x] cd api && npm run lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
