### PR TITLE
Fix: bump form-data to patched versions in /api (GHSA-hmw2-7cc7-3qxx)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -3572,15 +3572,15 @@
       }
     },
     "node_modules/@types/request/node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -7424,16 +7424,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -8031,9 +8031,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },


### PR DESCRIPTION
## Summary
- Fixes Dependabot security alert [#300](https://github.com/windy10v10ai/firebase/security/dependabot/300) (CVE-2026-12143 / GHSA-hmw2-7cc7-3qxx, CVSS 7.5 High)
- `form-data` < 4.0.6 / < 2.5.6 doesn't escape CR, LF, or `"` in multipart field names/filenames, allowing CRLF injection into the `Content-Disposition` header
- Bumps the two vulnerable transitive versions in `api/package-lock.json`: `form-data` 2.5.5 → 2.5.6 (via `@types/request`) and 4.0.5 → 4.0.6 (top-level, used by `superagent`/`urllib`), plus their shared `hasown` dependency 2.0.2 → 2.0.4
- No direct dependency in `api/package.json` needed to change; done via `npm update form-data`

## Test plan
- [x] `npm run lint` (api) — clean
- [x] `npm run test` (api unit) — 167 passed
- [x] `npm run test:e2e` (api, with Firestore emulator) — 235 passed
- [x] `npm ci` succeeds with the updated lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)