### PR TITLE
Fix: bump @nestjs/core for patched path-to-regexp in /api (GHSA-j3q9-mxjg-w52f)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2593,16 +2593,14 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "11.1.9",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.9.tgz",
-      "integrity": "sha512-a00B0BM4X+9z+t3UxJqIZlemIwCQdYoPKrMcM+ky4z3pkqqG1eTWexjs+YXpGObnLnjtMPVKWlcZHp3adDYvUw==",
-      "hasInstallScript": true,
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.28.tgz",
+      "integrity": "sha512-06m63xIRj8+l8uOeh/8LnYupGubkyu4f+bPKIadaSui6vK9KpXgoz7HveT1yOVLcEt0M0oCOEW5EuEXZkEmBBQ==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
-        "path-to-regexp": "8.3.0",
+        "path-to-regexp": "8.4.2",
         "tslib": "2.8.1",
         "uid": "2.0.2"
       },
@@ -2897,16 +2895,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/@nestjs/platform-express/node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/@nestjs/platform-express/node_modules/raw-body": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
@@ -3046,16 +3034,6 @@
         }
       }
     },
-    "node_modules/@nestjs/swagger/node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.24",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.24.tgz",
@@ -3109,22 +3087,6 @@
       ],
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@nuxt/opencollective": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
-      "integrity": "sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "consola": "^3.2.3"
-      },
-      "bin": {
-        "opencollective": "bin/opencollective.js"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0",
-        "npm": ">=5.10.0"
-      }
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
@@ -5627,15 +5589,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/consola": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
-      "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/content-disposition": {
@@ -10635,9 +10588,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
## Summary
- Fixes Dependabot security alert [#208](https://github.com/windy10v10ai/firebase/security/dependabot/208) (CVE-2026-4926 / GHSA-j3q9-mxjg-w52f, CVSS 7.5 High)
- `path-to-regexp` >= 8.0.0, < 8.4.0 generates an exponential-time regex for route patterns with multiple sequential optional groups (ReDoS)
- The vulnerable `path-to-regexp@8.3.0` was pinned exactly by `@nestjs/core@11.1.9`; `@nestjs/core` >= 11.1.10 depends on the patched `path-to-regexp@8.4.2`
- Bumped `@nestjs/core` 11.1.9 → 11.1.28 via `npm update`, within the existing `^11.1.9` range in `api/package.json` — no `package.json` change needed
- Side effect: the now-duplicate `path-to-regexp@8.4.2` copies under `@nestjs/platform-express`/`@nestjs/swagger` dedupe into the single top-level patched version, and the unused `@nuxt/opencollective`/`consola` postinstall deps that old `@nestjs/core` pulled in are dropped

## Test plan
- [x] `npm run lint` (api) — clean
- [x] `npm run test` (api unit) — 167 passed
- [x] `npm run test:e2e` (api, with Firestore emulator) — 235 passed
- [x] `npm ci` succeeds with the updated lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)