### PR TITLE
Fix(web): pin @swc/helpers via overrides to stop recurring lockfile drift

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2221,9 +2221,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -7118,17 +7118,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/web/package.json
+++ b/web/package.json
@@ -31,5 +31,8 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.9.3"
+  },
+  "overrides": {
+    "@swc/helpers": "^0.5.17"
   }
 }


### PR DESCRIPTION
## Summary
- Root cause of the repeated `npm ci` CI failure seen on #983, #959, and #989: `next@15.5.18` hard-pins `@swc/helpers@0.5.15`, but `next-intl`'s nested `@swc/core` has an optional peer dependency on `@swc/helpers >=0.5.17`. Since 0.5.15 doesn't satisfy that range, npm resolves a *second*, nested copy at `next-intl/node_modules/@swc/helpers`.
- That nested optional-peer entry is only computed correctly by a full `npm install`. Dependabot's lockfile patcher doesn't recompute optional peer trees when it bumps unrelated packages, so it keeps dropping this entry — breaking `npm ci` in CI every time.
- Fix: add `"overrides": { "@swc/helpers": "^0.5.17" }` to `web/package.json`, forcing a single top-level `@swc/helpers` version that satisfies both `next` and `next-intl`'s nested peer requirement. This collapses the tree to one copy and eliminates the nested entry entirely, so Dependabot can no longer drop it.
- Verified this isn't fixable by upgrading Next.js instead — checked up to `next@16.0.0` stable, which still pins `@swc/helpers` at exactly `0.5.15`.

## Test plan
- [x] `npm ci` succeeds with the new lockfile
- [x] `npm run lint` (web) — clean
- [x] `npm run build` (web) — compiles and generates all static pages successfully, including `next-intl` pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)