### PR TITLE
URGENT: Revert #994 — broke standalone deploy in production

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2221,9 +2221,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -7118,6 +7118,17 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/web/package.json
+++ b/web/package.json
@@ -31,8 +31,5 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.9.3"
-  },
-  "overrides": {
-    "@swc/helpers": "^0.5.17"
   }
 }


### PR DESCRIPTION
## Summary
- **Reverts #994.** That PR forced a single top-level `@swc/helpers` version via `overrides` to stop a recurring Dependabot lockfile-drift issue, but it broke the `output: 'standalone'` production build.
- Deploy failure (Cloud Run `dev` service, revision `dev-build-2026-07-21-004`, ~4 min after #994 merged):
  ```
  Error: Cannot find module '/workspace/web/.next/standalone/node_modules/@swc/helpers/esm/_interop_require_default.js'
  ...
  Node.js v22.23.1
  Container called exit(1).
  ```
- Root cause: with `@swc/helpers` deduped to a single top-level copy, `next-intl`'s SWC-compiled output resolves its helper imports through the top-level `@swc/helpers` package, but Next's `outputFileTracing` doesn't fully trace/copy that package's `esm/*.js` files into `.next/standalone/node_modules` when it's Next's own direct dependency (Next appears to special-case tracing for its own directly-declared `@swc/helpers`, copying only what its own compiler needs — not the `esm/*` files that `next-intl`'s independently-versioned SWC transform requires by literal path). Before #994, this worked because `next-intl` had its own **nested** copy of `@swc/helpers` (under `next-intl/node_modules/`), which nft traced normally as a third-party dependency and copied in full, including `esm/*`.
- Verified locally: built the standalone output from `develop` (with #994) and ran `node .next/standalone/server.js` — reproduces the exact `MODULE_NOT_FOUND` crash. Reverting and rebuilding: server starts and serves `/` and `/products` (a `next-intl` locale route) with HTTP 200.

This restores the known-good state. The original Dependabot lockfile-drift problem (#983, #959, #989) is **not re-solved** by this revert — future `web` Dependabot PRs will likely hit the same `Missing: @swc/helpers@0.5.23 from lock file` CI failure again and need the manual `npm install` lockfile-regeneration fix applied per-PR, as done before. A real fix needs an approach that doesn't collapse `@swc/helpers` to a single top-level copy (e.g., patching Dependabot's lockfile PRs directly, or a repo script/CI job that runs `npm install` and pushes a fixup commit automatically) — to be investigated separately, with standalone-server smoke testing as part of validation next time.

## Test plan
- [x] `npm run lint` (web) — clean
- [x] `npm run build` (web) — succeeds
- [x] Ran the actual standalone server (`node .next/standalone/server.js`) after revert — starts cleanly, `/` and `/products` return HTTP 200
- [x] Confirmed the pre-revert (current `develop`) standalone server reproduces the exact production crash locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)