### PR TITLE
Feat(api): add property_aoe_bonus_constant_stacking to property whitelist

### DIFF
--- a/api/src/player-property/player-property.service.ts
+++ b/api/src/player-property/player-property.service.ts
@@ -49,6 +49,7 @@ export class PlayerPropertyService {
     'property_cannot_miss',
     'property_slow_immune',
     'property_flying',
+    'property_aoe_bonus_constant_stacking',
   ];
 
   constructor(


### PR DESCRIPTION
## Summary
- Adds `'property_aoe_bonus_constant_stacking'` to `PlayerPropertyService.PROPERTY_NAME_LIST` in `api/src/player-property/player-property.service.ts`
- Game client (windy10v10ai/game) added a new "AOE bonus" attribute that maps to Dota's native `MODIFIER_PROPERTY_AOE_BONUS_CONSTANT_STACKING` (8 levels, +15/level). Without this entry, upgrade requests are rejected by `validatePropertyName` with `BadRequestException`.

Closes #999, relates to windy10v10ai/game#2017

## Test plan
- [x] `npm run lint` (api) — pass
- [x] `npm run test` (api unit) — 167 tests pass
- [x] `npm run test:e2e` (api e2e w/ Firestore emulator) — 235 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)