### PR TITLE
PlayerSetting: 删除 ward 改键字段，新增背包 7/8/9 格改键字段

### DIFF
--- a/api/src/player/entities/player-setting.entity.ts
+++ b/api/src/player/entities/player-setting.entity.ts
@@ -54,15 +54,19 @@ export class PlayerSetting {
   @ApiProperty()
   passiveAbilityQuickCast2: boolean;
 
-  // 真假眼改键
+  // 背包 7/8/9 格改键
   @ApiProperty({ required: false })
-  wardObserverKey?: string;
+  inventorySlot7Key?: string;
   @ApiProperty({ required: false })
-  wardObserverQuickCast?: boolean;
+  inventorySlot7QuickCast?: boolean;
   @ApiProperty({ required: false })
-  wardSentryKey?: string;
+  inventorySlot8Key?: string;
   @ApiProperty({ required: false })
-  wardSentryQuickCast?: boolean;
+  inventorySlot8QuickCast?: boolean;
+  @ApiProperty({ required: false })
+  inventorySlot9Key?: string;
+  @ApiProperty({ required: false })
+  inventorySlot9QuickCast?: boolean;
 
   // 按地图游戏预设
   @ApiPropertyOptional()

--- a/api/src/player/player-setting.service.ts
+++ b/api/src/player/player-setting.service.ts
@@ -30,11 +30,23 @@ export class PlayerSettingService {
     if (updatePlayerSettingDto.passiveAbilityQuickCast2 !== undefined) {
       setting.passiveAbilityQuickCast2 = updatePlayerSettingDto.passiveAbilityQuickCast2;
     }
-    if (updatePlayerSettingDto.wardObserverQuickCast !== undefined) {
-      setting.wardObserverQuickCast = updatePlayerSettingDto.wardObserverQuickCast;
+    if (updatePlayerSettingDto.inventorySlot7Key !== undefined) {
+      setting.inventorySlot7Key = updatePlayerSettingDto.inventorySlot7Key;
     }
-    if (updatePlayerSettingDto.wardSentryQuickCast !== undefined) {
-      setting.wardSentryQuickCast = updatePlayerSettingDto.wardSentryQuickCast;
+    if (updatePlayerSettingDto.inventorySlot7QuickCast !== undefined) {
+      setting.inventorySlot7QuickCast = updatePlayerSettingDto.inventorySlot7QuickCast;
+    }
+    if (updatePlayerSettingDto.inventorySlot8Key !== undefined) {
+      setting.inventorySlot8Key = updatePlayerSettingDto.inventorySlot8Key;
+    }
+    if (updatePlayerSettingDto.inventorySlot8QuickCast !== undefined) {
+      setting.inventorySlot8QuickCast = updatePlayerSettingDto.inventorySlot8QuickCast;
+    }
+    if (updatePlayerSettingDto.inventorySlot9Key !== undefined) {
+      setting.inventorySlot9Key = updatePlayerSettingDto.inventorySlot9Key;
+    }
+    if (updatePlayerSettingDto.inventorySlot9QuickCast !== undefined) {
+      setting.inventorySlot9QuickCast = updatePlayerSettingDto.inventorySlot9QuickCast;
     }
     if (setting.isRememberAbilityKey) {
       if (updatePlayerSettingDto.activeAbilityKey !== undefined) {
@@ -46,18 +58,10 @@ export class PlayerSettingService {
       if (updatePlayerSettingDto.passiveAbilityKey2 !== undefined) {
         setting.passiveAbilityKey2 = updatePlayerSettingDto.passiveAbilityKey2;
       }
-      if (updatePlayerSettingDto.wardObserverKey !== undefined) {
-        setting.wardObserverKey = updatePlayerSettingDto.wardObserverKey;
-      }
-      if (updatePlayerSettingDto.wardSentryKey !== undefined) {
-        setting.wardSentryKey = updatePlayerSettingDto.wardSentryKey;
-      }
     } else {
       setting.activeAbilityKey = '';
       setting.passiveAbilityKey = '';
       setting.passiveAbilityKey2 = '';
-      setting.wardObserverKey = '';
-      setting.wardSentryKey = '';
     }
     setting.updatedAt = new Date();
     return this.playerSettingRepository.update(setting);
@@ -87,10 +91,12 @@ export class PlayerSettingService {
       activeAbilityQuickCast: false,
       passiveAbilityQuickCast: false,
       passiveAbilityQuickCast2: false,
-      wardObserverKey: '',
-      wardObserverQuickCast: false,
-      wardSentryKey: '',
-      wardSentryQuickCast: false,
+      inventorySlot7Key: '',
+      inventorySlot7QuickCast: false,
+      inventorySlot8Key: '',
+      inventorySlot8QuickCast: false,
+      inventorySlot9Key: '',
+      inventorySlot9QuickCast: false,
       createdAt: new Date(),
       updatedAt: new Date(),
     };

--- a/api/test/player-setting.e2e-spec.ts
+++ b/api/test/player-setting.e2e-spec.ts
@@ -24,10 +24,12 @@ describe('PlayerSettingController (e2e)', () => {
         activeAbilityQuickCast: false,
         passiveAbilityQuickCast: false,
         passiveAbilityQuickCast2: false,
-        wardObserverKey: '',
-        wardObserverQuickCast: false,
-        wardSentryKey: '',
-        wardSentryQuickCast: false,
+        inventorySlot7Key: '',
+        inventorySlot7QuickCast: false,
+        inventorySlot8Key: '',
+        inventorySlot8QuickCast: false,
+        inventorySlot9Key: '',
+        inventorySlot9QuickCast: false,
         createdAt: expect.any(Date),
         updatedAt: expect.any(Date),
       });
@@ -43,10 +45,12 @@ describe('PlayerSettingController (e2e)', () => {
         activeAbilityQuickCast: true,
         passiveAbilityQuickCast: true,
         passiveAbilityQuickCast2: false,
-        wardObserverKey: 'Y',
-        wardObserverQuickCast: true,
-        wardSentryKey: 'U',
-        wardSentryQuickCast: false,
+        inventorySlot7Key: 'F1',
+        inventorySlot7QuickCast: true,
+        inventorySlot8Key: 'F2',
+        inventorySlot8QuickCast: false,
+        inventorySlot9Key: 'F3',
+        inventorySlot9QuickCast: true,
       };
 
       const response = await put(app, `${playerUrl}/${testPlayer}/setting`, updateData);
@@ -68,15 +72,17 @@ describe('PlayerSettingController (e2e)', () => {
       expect(playerSetting.activeAbilityQuickCast).toEqual(true);
       expect(playerSetting.passiveAbilityQuickCast).toEqual(true);
       expect(playerSetting.passiveAbilityQuickCast2).toEqual(false);
-      expect(playerSetting.wardObserverKey).toEqual('Y');
-      expect(playerSetting.wardObserverQuickCast).toEqual(true);
-      expect(playerSetting.wardSentryKey).toEqual('U');
-      expect(playerSetting.wardSentryQuickCast).toEqual(false);
+      expect(playerSetting.inventorySlot7Key).toEqual('F1');
+      expect(playerSetting.inventorySlot7QuickCast).toEqual(true);
+      expect(playerSetting.inventorySlot8Key).toEqual('F2');
+      expect(playerSetting.inventorySlot8QuickCast).toEqual(false);
+      expect(playerSetting.inventorySlot9Key).toEqual('F3');
+      expect(playerSetting.inventorySlot9QuickCast).toEqual(true);
     });
 
-    it('更新玩家设置 - 默认不记住快捷键但保留快速施法', async () => {
+    it('更新玩家设置 - 默认不记住快捷键但保留快速施法和背包格改键', async () => {
       const testPlayer = 300400003;
-      // 先设置快捷键和快速施法
+      // 先设置快捷键、快速施法和背包格改键
       const response = await put(app, `${playerUrl}/${testPlayer}/setting`, {
         activeAbilityKey: 'Q',
         passiveAbilityKey: 'E',
@@ -84,10 +90,12 @@ describe('PlayerSettingController (e2e)', () => {
         activeAbilityQuickCast: true,
         passiveAbilityQuickCast: false,
         passiveAbilityQuickCast2: true,
-        wardObserverKey: 'Y',
-        wardObserverQuickCast: true,
-        wardSentryKey: 'U',
-        wardSentryQuickCast: true,
+        inventorySlot7Key: 'F1',
+        inventorySlot7QuickCast: true,
+        inventorySlot8Key: 'F2',
+        inventorySlot8QuickCast: false,
+        inventorySlot9Key: 'F3',
+        inventorySlot9QuickCast: true,
       });
 
       expect(response.status).toEqual(200);
@@ -101,10 +109,12 @@ describe('PlayerSettingController (e2e)', () => {
           activeAbilityQuickCast: true,
           passiveAbilityQuickCast: false,
           passiveAbilityQuickCast2: true,
-          wardObserverKey: '',
-          wardObserverQuickCast: true,
-          wardSentryKey: '',
-          wardSentryQuickCast: true,
+          inventorySlot7Key: 'F1',
+          inventorySlot7QuickCast: true,
+          inventorySlot8Key: 'F2',
+          inventorySlot8QuickCast: false,
+          inventorySlot9Key: 'F3',
+          inventorySlot9QuickCast: true,
         }),
       );
 
@@ -118,15 +128,17 @@ describe('PlayerSettingController (e2e)', () => {
       expect(playerSetting.activeAbilityQuickCast).toEqual(true);
       expect(playerSetting.passiveAbilityQuickCast).toEqual(false);
       expect(playerSetting.passiveAbilityQuickCast2).toEqual(true);
-      expect(playerSetting.wardObserverKey).toEqual('');
-      expect(playerSetting.wardObserverQuickCast).toEqual(true);
-      expect(playerSetting.wardSentryKey).toEqual('');
-      expect(playerSetting.wardSentryQuickCast).toEqual(true);
+      expect(playerSetting.inventorySlot7Key).toEqual('F1');
+      expect(playerSetting.inventorySlot7QuickCast).toEqual(true);
+      expect(playerSetting.inventorySlot8Key).toEqual('F2');
+      expect(playerSetting.inventorySlot8QuickCast).toEqual(false);
+      expect(playerSetting.inventorySlot9Key).toEqual('F3');
+      expect(playerSetting.inventorySlot9QuickCast).toEqual(true);
     });
 
-    it('更新玩家设置 - 记忆快捷键后，再取消记忆快捷键但保留快速施法', async () => {
+    it('更新玩家设置 - 记忆技能改键后，再取消记忆但保留快速施法和背包格改键', async () => {
       const testPlayer = 300400004;
-      // 先设置快捷键和快速施法
+      // 先设置快捷键、快速施法和背包格改键
       await put(app, `${playerUrl}/${testPlayer}/setting`, {
         isRememberAbilityKey: true,
         activeAbilityKey: 'Q',
@@ -135,13 +147,15 @@ describe('PlayerSettingController (e2e)', () => {
         activeAbilityQuickCast: true,
         passiveAbilityQuickCast: false,
         passiveAbilityQuickCast2: true,
-        wardObserverKey: 'Y',
-        wardObserverQuickCast: true,
-        wardSentryKey: 'U',
-        wardSentryQuickCast: true,
+        inventorySlot7Key: 'F1',
+        inventorySlot7QuickCast: true,
+        inventorySlot8Key: 'F2',
+        inventorySlot8QuickCast: false,
+        inventorySlot9Key: 'F3',
+        inventorySlot9QuickCast: true,
       });
 
-      // 设置不记住快捷键
+      // 设置不记住技能改键
       const updateData = {
         isRememberAbilityKey: false,
       };
@@ -158,14 +172,16 @@ describe('PlayerSettingController (e2e)', () => {
           activeAbilityQuickCast: true,
           passiveAbilityQuickCast: false,
           passiveAbilityQuickCast2: true,
-          wardObserverKey: '',
-          wardObserverQuickCast: true,
-          wardSentryKey: '',
-          wardSentryQuickCast: true,
+          inventorySlot7Key: 'F1',
+          inventorySlot7QuickCast: true,
+          inventorySlot8Key: 'F2',
+          inventorySlot8QuickCast: false,
+          inventorySlot9Key: 'F3',
+          inventorySlot9QuickCast: true,
         }),
       );
 
-      // 验证更新后的设置
+      // 验证更新后的设置：技能改键被清空，背包格改键与快速施法保留
       const playerSetting = await getPlayerSetting(app, testPlayer.toString());
       expect(playerSetting.id).toEqual(testPlayer.toString());
       expect(playerSetting.isRememberAbilityKey).toEqual(false);
@@ -175,10 +191,12 @@ describe('PlayerSettingController (e2e)', () => {
       expect(playerSetting.activeAbilityQuickCast).toEqual(true);
       expect(playerSetting.passiveAbilityQuickCast).toEqual(false);
       expect(playerSetting.passiveAbilityQuickCast2).toEqual(true);
-      expect(playerSetting.wardObserverKey).toEqual('');
-      expect(playerSetting.wardObserverQuickCast).toEqual(true);
-      expect(playerSetting.wardSentryKey).toEqual('');
-      expect(playerSetting.wardSentryQuickCast).toEqual(true);
+      expect(playerSetting.inventorySlot7Key).toEqual('F1');
+      expect(playerSetting.inventorySlot7QuickCast).toEqual(true);
+      expect(playerSetting.inventorySlot8Key).toEqual('F2');
+      expect(playerSetting.inventorySlot8QuickCast).toEqual(false);
+      expect(playerSetting.inventorySlot9Key).toEqual('F3');
+      expect(playerSetting.inventorySlot9QuickCast).toEqual(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- 删除 `wardObserverKey`/`wardObserverQuickCast`/`wardSentryKey`/`wardSentryQuickCast` 4 个字段（真假眼额外槽位功能已由 game 侧扩容之书替代）
- 新增 `inventorySlot7/8/9Key` + `inventorySlot7/8/9QuickCast` 共 6 个字段，`PUT /player/{steamId}/setting` 通过既有 `UpdatePlayerSettingDto` 自动支持
- `isRememberAbilityKey` 收窄为只作用于 `activeAbilityKey`/`passiveAbilityKey`/`passiveAbilityKey2` 三个技能改键；背包格改键与所有 `QuickCast` 一样始终无条件写入/保留，不受该开关影响
- 顺带修复既有缺陷：`inventorySlot*` 字段此前从未接入 entity/service，game 侧发送的 7/8/9 格改键每局都会被静默丢弃

Closes #1003

## Test plan
- [x] `cd api && npm run test`（unit，167 passed）
- [x] `cd api && npm run test:e2e`（235 passed，含新增/更新的 `player-setting.e2e-spec.ts` 用例，覆盖默认值、记忆技能改键、`isRememberAbilityKey: false` 时技能 key 清空但背包格改键与快速施法保留）
- [x] `cd api && npm run lint`
- [x] 实现前先在旧代码上加了一条 e2e 用例复现 `inventorySlot*` 字段丢失的 bug，确认失败后再实现修复，验证转为通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)