### PR TITLE
Add admin endpoint to reset player property used level

### DIFF
--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -6,6 +6,7 @@ import { ActiveAfdianOrderDto } from '../afdian/dto/active-afdian-order.dto';
 import { CreateMemberDto } from '../members/dto/create-member.dto';
 import { MembersService } from '../members/members.service';
 import { PlayerHeroAwakeningCompensationService } from '../player-hero-awakening/player-hero-awakening-compensation.service';
+import { PlayerPropertyResetService } from '../player-property/player-property-reset.service';
 import { Public } from '../util/auth/public.decorator';
 
 import { AdminService } from './admin.service';
@@ -19,6 +20,7 @@ export class AdminController {
     private readonly afdianService: AfdianService,
     private readonly membersService: MembersService,
     private readonly playerHeroAwakeningCompensationService: PlayerHeroAwakeningCompensationService,
+    private readonly playerPropertyResetService: PlayerPropertyResetService,
   ) {}
 
   @Post('/member')
@@ -50,5 +52,11 @@ export class AdminController {
   @Post('/hero-awakening/compensation')
   runHeroAwakeningCompensation() {
     return this.playerHeroAwakeningCompensationService.runCompensation();
+  }
+
+  // 批量重置所有 usedLevel 与 PlayerProperty 不一致的玩家属性加点，供后续需要重置属性时复用
+  @Post('/player-property/reset')
+  resetPlayerProperty() {
+    return this.playerPropertyResetService.resetAll();
   }
 }

--- a/api/src/admin/admin.module.ts
+++ b/api/src/admin/admin.module.ts
@@ -5,6 +5,7 @@ import { AfdianModule } from '../afdian/afdian.module';
 import { KofiOrder } from '../kofi/entities/kofi-order.entity';
 import { MembersModule } from '../members/members.module';
 import { PlayerHeroAwakeningModule } from '../player-hero-awakening/player-hero-awakening.module';
+import { PlayerPropertyModule } from '../player-property/player-property.module';
 
 import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
@@ -15,6 +16,7 @@ import { AdminService } from './admin.service';
     AfdianModule,
     // TODO: 仅为一次性 hero-awakening 补偿迁移端点引入，随机觉醒上线执行完后删除
     PlayerHeroAwakeningModule,
+    PlayerPropertyModule,
     FireormModule.forFeature([KofiOrder]),
   ],
   controllers: [AdminController],

--- a/api/src/player-property/player-property-reset.service.ts
+++ b/api/src/player-property/player-property-reset.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { logger } from 'firebase-functions';
+
+import { PlayerService } from '../player/player.service';
+
+import { PlayerPropertyService } from './player-property.service';
+
+export interface PlayerPropertyResetResult {
+  processedCount: number;
+}
+
+@Injectable()
+export class PlayerPropertyResetService {
+  constructor(
+    private readonly playerService: PlayerService,
+    private readonly playerPropertyService: PlayerPropertyService,
+  ) {}
+
+  /**
+   * 找出所有 usedLevel > 0 的玩家，对每个玩家执行 deleteBySteamId
+   *（删除 PlayerProperty 文档 + 将 player.usedLevel 重置为 0），可重复执行。
+   * 供运维在需要批量重置玩家属性加点时调用（例如直接操作数据后忘记同步 usedLevel）。
+   */
+  async resetAll(): Promise<PlayerPropertyResetResult> {
+    const players = await this.playerService.findAllWithUsedLevelGreaterThanZero();
+
+    for (const player of players) {
+      const steamId = Number(player.id);
+      await this.playerPropertyService.deleteBySteamId(steamId);
+      logger.log('[Player Property Reset] reset', {
+        steamId,
+        previousUsedLevel: player.usedLevel,
+      });
+    }
+
+    return { processedCount: players.length };
+  }
+}

--- a/api/src/player-property/player-property-reset.service.ts
+++ b/api/src/player-property/player-property-reset.service.ts
@@ -23,16 +23,22 @@ export class PlayerPropertyResetService {
    */
   async resetAll(): Promise<PlayerPropertyResetResult> {
     const players = await this.playerService.findAllWithUsedLevelGreaterThanZero();
+    const total = players.length;
+    logger.log('[Player Property Reset] start', { total });
 
+    let processed = 0;
     for (const player of players) {
       const steamId = Number(player.id);
       await this.playerPropertyService.deleteBySteamId(steamId);
+      processed++;
       logger.log('[Player Property Reset] reset', {
         steamId,
         previousUsedLevel: player.usedLevel,
+        progress: `${processed}/${total}`,
       });
     }
 
-    return { processedCount: players.length };
+    logger.log('[Player Property Reset] done', { processedCount: processed });
+    return { processedCount: processed };
   }
 }

--- a/api/src/player-property/player-property.module.ts
+++ b/api/src/player-property/player-property.module.ts
@@ -5,12 +5,13 @@ import { AnalyticsModule } from '../analytics/analytics.module';
 import { PlayerModule } from '../player/player.module';
 
 import { PlayerProperty } from './entities/player-property.entity';
+import { PlayerPropertyResetService } from './player-property-reset.service';
 import { PlayerPropertyService } from './player-property.service';
 
 @Module({
   imports: [FireormModule.forFeature([PlayerProperty]), PlayerModule, AnalyticsModule],
   controllers: [],
-  providers: [PlayerPropertyService],
-  exports: [PlayerPropertyService],
+  providers: [PlayerPropertyService, PlayerPropertyResetService],
+  exports: [PlayerPropertyService, PlayerPropertyResetService],
 })
 export class PlayerPropertyModule {}

--- a/api/src/player/player.service.ts
+++ b/api/src/player/player.service.ts
@@ -84,6 +84,10 @@ export class PlayerService {
     return players;
   }
 
+  async findAllWithUsedLevelGreaterThanZero(): Promise<Player[]> {
+    return this.playerRepository.whereGreaterThan('usedLevel', 0).find();
+  }
+
   async reduceUsedPoint(
     steamId: number,
     dto: Pick<UpdatePlayerDto, 'usedSeasonPoint' | 'usedMemberPoint'>,

--- a/api/test/player-property-reset.e2e-spec.ts
+++ b/api/test/player-property-reset.e2e-spec.ts
@@ -1,0 +1,80 @@
+import { INestApplication } from '@nestjs/common';
+import { BaseFirestoreRepository } from 'fireorm';
+import { getRepositoryToken } from 'nestjs-fireorm';
+
+import { PlayerProperty } from '../src/player-property/entities/player-property.entity';
+
+import { initTest, post } from './util/util-http';
+import { addPlayerProperty, createPlayer, getPlayer } from './util/util-player';
+
+describe('AdminController - player-property/reset (e2e)', () => {
+  const resetUrl = '/api/admin/player-property/reset';
+  let app: INestApplication;
+  let playerPropertyRepository: BaseFirestoreRepository<PlayerProperty>;
+
+  beforeAll(async () => {
+    app = await initTest();
+    playerPropertyRepository = app.get<BaseFirestoreRepository<PlayerProperty>>(
+      getRepositoryToken(PlayerProperty),
+    );
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('复现并修复：绕过 service 直接删除 PlayerProperty 文档后，usedLevel 未被重置', async () => {
+    const testPlayer = 300600001;
+    await createPlayer(app, { steamId: testPlayer, seasonPointTotal: 100000 });
+    await addPlayerProperty(app, testPlayer, 'property_cooldown_percentage', 3);
+
+    const beforeBypassDelete = await getPlayer(app, testPlayer);
+    expect(beforeBypassDelete.usedLevel).toEqual(3);
+
+    // 模拟绕过 service 直接删除 PlayerProperty 文档（复现本次线上问题：usedLevel 未被重置）
+    await playerPropertyRepository.delete(testPlayer.toString());
+
+    const afterBypassDelete = await getPlayer(app, testPlayer);
+    expect(afterBypassDelete.usedLevel).toEqual(3);
+
+    const response = await post(app, resetUrl, {});
+
+    expect(response.status).toEqual(201);
+    expect(response.body).toEqual({ processedCount: expect.any(Number) });
+    expect(response.body.processedCount).toBeGreaterThanOrEqual(1);
+
+    const afterFix = await getPlayer(app, testPlayer);
+    expect(afterFix.usedLevel).toEqual(0);
+  });
+
+  it('未受影响玩家（usedLevel 本就为 0）不受端点影响', async () => {
+    const testPlayer = 300600002;
+    await createPlayer(app, { steamId: testPlayer, seasonPointTotal: 100000 });
+
+    const before = await getPlayer(app, testPlayer);
+    expect(before.usedLevel).toEqual(0);
+
+    const response = await post(app, resetUrl, {});
+    expect(response.status).toEqual(201);
+
+    const after = await getPlayer(app, testPlayer);
+    expect(after.usedLevel).toEqual(0);
+  });
+
+  it('端点幂等：连续执行两次结果一致', async () => {
+    const testPlayer = 300600003;
+    await createPlayer(app, { steamId: testPlayer, seasonPointTotal: 100000 });
+    await addPlayerProperty(app, testPlayer, 'property_cooldown_percentage', 2);
+    await playerPropertyRepository.delete(testPlayer.toString());
+
+    const first = await post(app, resetUrl, {});
+    expect(first.status).toEqual(201);
+    const afterFirst = await getPlayer(app, testPlayer);
+    expect(afterFirst.usedLevel).toEqual(0);
+
+    const second = await post(app, resetUrl, {});
+    expect(second.status).toEqual(201);
+    const afterSecond = await getPlayer(app, testPlayer);
+    expect(afterSecond.usedLevel).toEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `POST /admin/player-property/reset`: bulk-resets every player whose `usedLevel > 0` by deleting their `PlayerProperty` doc and zeroing `player.usedLevel` (reuses the existing `PlayerPropertyService.deleteBySteamId`). Idempotent, safe to run repeatedly.
- Fixes the case where `PlayerProperty` data was deleted directly (bypassing the service) without resyncing `player.usedLevel`, leaving players seeing points as still "used" until their next property upgrade recalculated it.
- Designed as a permanent, reusable admin utility rather than a one-off migration endpoint, for future property-reset needs.

## Test plan
- [x] `npm run test` (unit, 167 passed)
- [x] `npm run test:e2e` (238 passed, new spec reproduces the bug first via a bypassed delete, then verifies the fix and idempotency)
- [x] `npm run lint`