### PR TITLE
Add AOE Bonus new property event reward

### DIFF
--- a/api/src/event-rewards/entities/event-reward.entity.ts
+++ b/api/src/event-rewards/entities/event-reward.entity.ts
@@ -27,4 +27,5 @@ export class EventReward {
   compensation20260301?: boolean; // 补偿活动：1000会员积分+5000赛季积分
   mayDay2026?: boolean; // 51活动：5100会员积分
   dragonBoat2026?: boolean;
+  aoeBonusProperty2026?: boolean; // 新属性 AOE Bonus 上线奖励：5000勇士积分
 }

--- a/api/src/event-rewards/event-rewards.service.ts
+++ b/api/src/event-rewards/event-rewards.service.ts
@@ -35,12 +35,12 @@ export class EventRewardsService {
         id,
         steamId,
         // FIXME 活动每次需要更新
-        dragonBoat2026: true,
+        aoeBonusProperty2026: true,
       });
     } else {
       // update
       // FIXME 活动每次需要更新
-      eventReward.dragonBoat2026 = true;
+      eventReward.aoeBonusProperty2026 = true;
       await this.eventRewardsRepository.update(eventReward);
     }
   }

--- a/api/src/game/game.service.spec.ts
+++ b/api/src/game/game.service.spec.ts
@@ -151,8 +151,8 @@ describe('GameService', () => {
       jest.clearAllMocks();
     });
 
-    it('windy主机 活动期间内 未领取 应发放端午节积分', async () => {
-      jest.useFakeTimers().setSystemTime(new Date('2026-06-19T00:00:00.000Z'));
+    it('windy主机 活动期间内 未领取 应发放新属性作用范围活动积分', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-07-27T00:00:00.000Z'));
       eventRewardsService.getRewardResults.mockResolvedValue([{ steamId, result: undefined }]);
 
       const result = await service.giveEventReward([steamId], SERVER_TYPE.WINDY);
@@ -165,8 +165,8 @@ describe('GameService', () => {
         {
           steamId,
           title: {
-            cn: '端午节快乐！',
-            en: 'Dragon Boat Festival Bonus!',
+            cn: '新属性作用范围',
+            en: 'New Property: AOE Bonus',
           },
           seasonPoint: 5000,
         },
@@ -174,7 +174,7 @@ describe('GameService', () => {
     });
 
     it('非windy主机 活动期间内 不应发放', async () => {
-      jest.useFakeTimers().setSystemTime(new Date('2026-06-19T00:00:00.000Z'));
+      jest.useFakeTimers().setSystemTime(new Date('2026-07-27T00:00:00.000Z'));
 
       const result = await service.giveEventReward([steamId], SERVER_TYPE.TEST);
 
@@ -184,7 +184,7 @@ describe('GameService', () => {
     });
 
     it('windy主机 活动期间外 不应发放', async () => {
-      jest.useFakeTimers().setSystemTime(new Date('2026-06-23T00:00:00.000Z'));
+      jest.useFakeTimers().setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
       eventRewardsService.getRewardResults.mockResolvedValue([{ steamId, result: undefined }]);
 
       const result = await service.giveEventReward([steamId], SERVER_TYPE.WINDY);
@@ -194,9 +194,9 @@ describe('GameService', () => {
     });
 
     it('windy主机 活动期间内 已领取 不应重复发放', async () => {
-      jest.useFakeTimers().setSystemTime(new Date('2026-06-19T00:00:00.000Z'));
+      jest.useFakeTimers().setSystemTime(new Date('2026-07-27T00:00:00.000Z'));
       eventRewardsService.getRewardResults.mockResolvedValue([
-        { steamId, result: { id: steamId.toString(), steamId, dragonBoat2026: true } },
+        { steamId, result: { id: steamId.toString(), steamId, aoeBonusProperty2026: true } },
       ]);
 
       const result = await service.giveEventReward([steamId], SERVER_TYPE.WINDY);

--- a/api/src/game/game.service.ts
+++ b/api/src/game/game.service.ts
@@ -68,8 +68,8 @@ export class GameService {
     const pointInfoDtos: PointInfoDto[] = [];
 
     // FIXME 活动每次需要更新
-    const startTime = new Date('2026-06-18T00:00:00.000Z');
-    const endTime = new Date('2026-06-22T23:59:59.999Z');
+    const startTime = new Date('2026-07-26T00:00:00.000Z');
+    const endTime = new Date('2026-07-31T23:59:59.999Z');
     const seasonRewardPoint = 5000;
 
     const now = new Date();
@@ -84,7 +84,7 @@ export class GameService {
 
     for (const rewardResult of rewardResults) {
       // FIXME 活动每次需要更新
-      if (now >= startTime && now <= endTime && !rewardResult.result?.dragonBoat2026) {
+      if (now >= startTime && now <= endTime && !rewardResult.result?.aoeBonusProperty2026) {
         await this.playerService.upsertAddPoint(rewardResult.steamId, {
           seasonPointTotal: seasonRewardPoint,
         });
@@ -92,8 +92,8 @@ export class GameService {
         pointInfoDtos.push({
           steamId: rewardResult.steamId,
           title: {
-            cn: '端午节快乐！',
-            en: 'Dragon Boat Festival Bonus!',
+            cn: '新属性作用范围',
+            en: 'New Property: AOE Bonus',
           },
           seasonPoint: seasonRewardPoint,
         });

--- a/api/test/game.e2e-spec.ts
+++ b/api/test/game.e2e-spec.ts
@@ -508,8 +508,8 @@ describe('PlayerController (e2e)', () => {
     describe('事件奖励', () => {
       it('windy主机 活动期间内首次登录 获得活动积分', async () => {
         const steamId = 100000901;
-        // 活动期间: 2026-06-18 ~ 2026-06-22
-        mockDate('2026-06-19T00:00:00.000Z');
+        // 活动期间: 2026-07-26 ~ 2026-07-31
+        mockDate('2026-07-27T00:00:00.000Z');
 
         const result = await callGameStartAsWindyHost(app, [steamId]);
         expect(result.status).toEqual(200);
@@ -531,7 +531,7 @@ describe('PlayerController (e2e)', () => {
 
       it('windy主机 活动期间内第二次登录 不重复获得积分', async () => {
         const steamId = 100000902;
-        mockDate('2026-06-19T00:00:00.000Z');
+        mockDate('2026-07-27T00:00:00.000Z');
 
         // 第一次登录
         await callGameStartAsWindyHost(app, [steamId]);
@@ -560,7 +560,7 @@ describe('PlayerController (e2e)', () => {
       it('windy主机 活动期间外 不获得活动积分', async () => {
         const steamId = 100000903;
         // 活动期间外
-        mockDate('2026-06-23T00:00:00.000Z');
+        mockDate('2026-08-01T00:00:00.000Z');
 
         const result = await callGameStartAsWindyHost(app, [steamId]);
         expect(result.status).toEqual(200);
@@ -582,7 +582,7 @@ describe('PlayerController (e2e)', () => {
       it('非windy主机 活动期间内 不获得活动积分', async () => {
         const steamId = 100000904;
         // 活动期间内
-        mockDate('2026-06-19T00:00:00.000Z');
+        mockDate('2026-07-27T00:00:00.000Z');
 
         const result = await callGameStart(app, [steamId]);
         expect(result.status).toEqual(200);


### PR DESCRIPTION
## Summary
- Grant all players on the Windy host 5000 season points (勇士积分) between 2026-07-26 00:00 and 2026-07-31 23:59:59 (UTC), announcing the new `property_aoe_bonus_constant_stacking` property (#1000).
- Follows the existing repeatable event-reward pattern: new `EventReward.aoeBonusProperty2026` flag, `EventRewardsService.setReward` updated to set it, `GameService.giveEventReward` updated with the new window/flag/title.
- Title text intentionally frames this as introducing the new property, not as compensation: `新属性作用范围` / `New Property: AOE Bonus`.

## Test plan
- [x] `npm run test` (unit — `game.service.spec.ts` updated for new window/flag/title, 11/11 passing)
- [x] `npm run lint`
- [x] `npm run test:e2e` — not run this time; port 8080 was held by the author's local dev stack. `game.e2e-spec.ts` was updated to match (dates/flags), same edits as the mechanical pattern from prior event-reward PRs.