### PR TITLE
Restore ward key setting fields, decouple from isRememberAbilityKey

### DIFF
--- a/api/src/player/entities/player-setting.entity.ts
+++ b/api/src/player/entities/player-setting.entity.ts
@@ -68,6 +68,16 @@ export class PlayerSetting {
   @ApiProperty({ required: false })
   inventorySlot9QuickCast?: boolean;
 
+  // 真假眼改键（不受 isRememberAbilityKey 影响，始终无条件写入/保留）
+  @ApiProperty({ required: false })
+  wardObserverKey?: string;
+  @ApiProperty({ required: false })
+  wardObserverQuickCast?: boolean;
+  @ApiProperty({ required: false })
+  wardSentryKey?: string;
+  @ApiProperty({ required: false })
+  wardSentryQuickCast?: boolean;
+
   // 按地图游戏预设
   @ApiPropertyOptional()
   gamePresetDota?: { difficulty: number };

--- a/api/src/player/player-setting.service.ts
+++ b/api/src/player/player-setting.service.ts
@@ -48,6 +48,18 @@ export class PlayerSettingService {
     if (updatePlayerSettingDto.inventorySlot9QuickCast !== undefined) {
       setting.inventorySlot9QuickCast = updatePlayerSettingDto.inventorySlot9QuickCast;
     }
+    if (updatePlayerSettingDto.wardObserverKey !== undefined) {
+      setting.wardObserverKey = updatePlayerSettingDto.wardObserverKey;
+    }
+    if (updatePlayerSettingDto.wardObserverQuickCast !== undefined) {
+      setting.wardObserverQuickCast = updatePlayerSettingDto.wardObserverQuickCast;
+    }
+    if (updatePlayerSettingDto.wardSentryKey !== undefined) {
+      setting.wardSentryKey = updatePlayerSettingDto.wardSentryKey;
+    }
+    if (updatePlayerSettingDto.wardSentryQuickCast !== undefined) {
+      setting.wardSentryQuickCast = updatePlayerSettingDto.wardSentryQuickCast;
+    }
     if (setting.isRememberAbilityKey) {
       if (updatePlayerSettingDto.activeAbilityKey !== undefined) {
         setting.activeAbilityKey = updatePlayerSettingDto.activeAbilityKey;
@@ -97,6 +109,10 @@ export class PlayerSettingService {
       inventorySlot8QuickCast: false,
       inventorySlot9Key: '',
       inventorySlot9QuickCast: false,
+      wardObserverKey: '',
+      wardObserverQuickCast: false,
+      wardSentryKey: '',
+      wardSentryQuickCast: false,
       createdAt: new Date(),
       updatedAt: new Date(),
     };

--- a/api/test/player-setting.e2e-spec.ts
+++ b/api/test/player-setting.e2e-spec.ts
@@ -30,6 +30,10 @@ describe('PlayerSettingController (e2e)', () => {
         inventorySlot8QuickCast: false,
         inventorySlot9Key: '',
         inventorySlot9QuickCast: false,
+        wardObserverKey: '',
+        wardObserverQuickCast: false,
+        wardSentryKey: '',
+        wardSentryQuickCast: false,
         createdAt: expect.any(Date),
         updatedAt: expect.any(Date),
       });
@@ -51,6 +55,10 @@ describe('PlayerSettingController (e2e)', () => {
         inventorySlot8QuickCast: false,
         inventorySlot9Key: 'F3',
         inventorySlot9QuickCast: true,
+        wardObserverKey: 'Y',
+        wardObserverQuickCast: true,
+        wardSentryKey: 'U',
+        wardSentryQuickCast: false,
       };
 
       const response = await put(app, `${playerUrl}/${testPlayer}/setting`, updateData);
@@ -78,11 +86,15 @@ describe('PlayerSettingController (e2e)', () => {
       expect(playerSetting.inventorySlot8QuickCast).toEqual(false);
       expect(playerSetting.inventorySlot9Key).toEqual('F3');
       expect(playerSetting.inventorySlot9QuickCast).toEqual(true);
+      expect(playerSetting.wardObserverKey).toEqual('Y');
+      expect(playerSetting.wardObserverQuickCast).toEqual(true);
+      expect(playerSetting.wardSentryKey).toEqual('U');
+      expect(playerSetting.wardSentryQuickCast).toEqual(false);
     });
 
-    it('更新玩家设置 - 默认不记住快捷键但保留快速施法和背包格改键', async () => {
+    it('更新玩家设置 - 默认不记住快捷键但保留快速施法、背包格改键和真假眼改键', async () => {
       const testPlayer = 300400003;
-      // 先设置快捷键、快速施法和背包格改键
+      // 先设置快捷键、快速施法、背包格改键和真假眼改键
       const response = await put(app, `${playerUrl}/${testPlayer}/setting`, {
         activeAbilityKey: 'Q',
         passiveAbilityKey: 'E',
@@ -96,6 +108,10 @@ describe('PlayerSettingController (e2e)', () => {
         inventorySlot8QuickCast: false,
         inventorySlot9Key: 'F3',
         inventorySlot9QuickCast: true,
+        wardObserverKey: 'Y',
+        wardObserverQuickCast: true,
+        wardSentryKey: 'U',
+        wardSentryQuickCast: true,
       });
 
       expect(response.status).toEqual(200);
@@ -115,6 +131,10 @@ describe('PlayerSettingController (e2e)', () => {
           inventorySlot8QuickCast: false,
           inventorySlot9Key: 'F3',
           inventorySlot9QuickCast: true,
+          wardObserverKey: 'Y',
+          wardObserverQuickCast: true,
+          wardSentryKey: 'U',
+          wardSentryQuickCast: true,
         }),
       );
 
@@ -134,11 +154,15 @@ describe('PlayerSettingController (e2e)', () => {
       expect(playerSetting.inventorySlot8QuickCast).toEqual(false);
       expect(playerSetting.inventorySlot9Key).toEqual('F3');
       expect(playerSetting.inventorySlot9QuickCast).toEqual(true);
+      expect(playerSetting.wardObserverKey).toEqual('Y');
+      expect(playerSetting.wardObserverQuickCast).toEqual(true);
+      expect(playerSetting.wardSentryKey).toEqual('U');
+      expect(playerSetting.wardSentryQuickCast).toEqual(true);
     });
 
-    it('更新玩家设置 - 记忆技能改键后，再取消记忆但保留快速施法和背包格改键', async () => {
+    it('更新玩家设置 - 记忆技能改键后，再取消记忆但保留快速施法、背包格改键和真假眼改键', async () => {
       const testPlayer = 300400004;
-      // 先设置快捷键、快速施法和背包格改键
+      // 先设置快捷键、快速施法、背包格改键和真假眼改键
       await put(app, `${playerUrl}/${testPlayer}/setting`, {
         isRememberAbilityKey: true,
         activeAbilityKey: 'Q',
@@ -153,6 +177,10 @@ describe('PlayerSettingController (e2e)', () => {
         inventorySlot8QuickCast: false,
         inventorySlot9Key: 'F3',
         inventorySlot9QuickCast: true,
+        wardObserverKey: 'Y',
+        wardObserverQuickCast: true,
+        wardSentryKey: 'U',
+        wardSentryQuickCast: true,
       });
 
       // 设置不记住技能改键
@@ -178,10 +206,14 @@ describe('PlayerSettingController (e2e)', () => {
           inventorySlot8QuickCast: false,
           inventorySlot9Key: 'F3',
           inventorySlot9QuickCast: true,
+          wardObserverKey: 'Y',
+          wardObserverQuickCast: true,
+          wardSentryKey: 'U',
+          wardSentryQuickCast: true,
         }),
       );
 
-      // 验证更新后的设置：技能改键被清空，背包格改键与快速施法保留
+      // 验证更新后的设置：技能改键被清空，背包格改键、真假眼改键与快速施法保留
       const playerSetting = await getPlayerSetting(app, testPlayer.toString());
       expect(playerSetting.id).toEqual(testPlayer.toString());
       expect(playerSetting.isRememberAbilityKey).toEqual(false);
@@ -197,6 +229,10 @@ describe('PlayerSettingController (e2e)', () => {
       expect(playerSetting.inventorySlot8QuickCast).toEqual(false);
       expect(playerSetting.inventorySlot9Key).toEqual('F3');
       expect(playerSetting.inventorySlot9QuickCast).toEqual(true);
+      expect(playerSetting.wardObserverKey).toEqual('Y');
+      expect(playerSetting.wardObserverQuickCast).toEqual(true);
+      expect(playerSetting.wardSentryKey).toEqual('U');
+      expect(playerSetting.wardSentryQuickCast).toEqual(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- 恢复 PR #1004 中删除的 `wardObserverKey`/`wardObserverQuickCast`/`wardSentryKey`/`wardSentryQuickCast` 4 个字段，与 `inventorySlot7/8/9` 并存
- 这 4 个字段（含 Key 字段）改为始终无条件写入/保留，不再受 `isRememberAbilityKey` 开关影响——行为与 `QuickCast` 字段以及背包格改键字段一致
- entity 新增字段 + 默认设置补齐 + e2e 用例覆盖：设置快捷键、`isRememberAbilityKey: false`（默认与主动取消两种场景）下真假眼改键与快速施法均保留

## Test plan
- [x] `cd api && npm run test`（unit，167 passed）
- [x] `cd api && npm run test:e2e`（235+ passed，含更新后的 `player-setting.e2e-spec.ts`，覆盖默认值、设置改键、`isRememberAbilityKey` 关闭时真假眼改键与快速施法不受影响）
- [x] `cd api && npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)