### PR TITLE
Fix(functions): cap scheduledOrderCheck timeout at Gen2 event limit

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -95,7 +95,7 @@ export const scheduledOrderCheck = onSchedule(
     region: 'asia-northeast1',
     minInstances: 0,
     maxInstances: 1,
-    timeoutSeconds: 1800,
+    timeoutSeconds: 540,
     secrets: commonSecrets,
   },
   async () => {


### PR DESCRIPTION
## Summary
- `scheduledOrderCheck` (`onSchedule`, a Gen2 event-triggered function) was configured with `timeoutSeconds: 1800`, which exceeds the platform's 540s cap for event-triggered functions (`MAX_EVENT_TIMEOUT_SECONDS` in the `firebase-functions` v2 SDK). HTTP-triggered functions (`onRequest`) can go up to 3600s, and Cloud Tasks queue functions (`onTaskDispatched`) up to 1800s, but `onSchedule` is internally categorized as `"event"`, capped at 540s.
- This was previously silent because `firebase-functions@7.2.5` didn't validate `timeoutSeconds` at all. After bumping to `7.3.0` (in #974, to resolve a peer-dependency conflict with `firebase-admin@14.x`), the SDK now throws `assertTimeoutSecondsValid` at module-load time. Since `client`, `admin`, and `scheduledOrderCheck` are all compiled into the same `dist/index.js`, the exception during `onSchedule(...)` crashed the entire functions codebase load in the Functions emulator — none of the three functions were reachable locally.
- Fix: lower `timeoutSeconds` for `scheduledOrderCheck` to `540` (the actual max for event-triggered functions).

## Test plan
- [x] Verified locally with an isolated Functions emulator instance: before the fix, `functions: Failed to load function definition from source: FirebaseError: Functions codebase could not be analyzed successfully`, all functions unreachable (`Function asia-northeast1-client does not exist, valid functions are:` — empty list); after the fix, `functions: Loaded functions definitions from source: client, admin, scheduledOrderCheck.` and requests route correctly.
- [ ] `cd api && npm run build`
- [ ] `cd api && npm run lint`
- [ ] `cd api && npm run test`
- [ ] `cd api && npm run test:e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)