### PR TITLE
Add awaken field to GameEndPlayerDto and GA4 game_end_player/bot events

### DIFF
--- a/api/src/analytics/analytics.service.spec.ts
+++ b/api/src/analytics/analytics.service.spec.ts
@@ -1,0 +1,70 @@
+import { SERVER_TYPE } from '../util/secret/secret.service';
+
+import { AnalyticsService } from './analytics.service';
+import { GameEndDto, GameEndPlayerDto } from './dto/game-end-dto';
+
+function buildPlayer(overrides: Partial<GameEndPlayerDto> = {}): GameEndPlayerDto {
+  return {
+    heroName: 'npc_dota_hero_abaddon',
+    steamId: 1,
+    teamId: 2,
+    isDisconnected: false,
+    level: 1,
+    totalGoldEarned: 0,
+    kills: 0,
+    deaths: 0,
+    assists: 0,
+    score: 0,
+    battlePoints: 0,
+    lastHits: 0,
+    heroDamage: 0,
+    damageTaken: 0,
+    healing: 0,
+    towerKills: 0,
+    ...overrides,
+  } as GameEndPlayerDto;
+}
+
+function buildGameEnd(players: GameEndPlayerDto[]): GameEndDto {
+  return {
+    matchId: '123',
+    version: 'v4.00',
+    difficulty: 0,
+    gameOptions: {
+      multiplierRadiant: 1,
+      multiplierDire: 1,
+      playerNumberRadiant: 1,
+      playerNumberDire: 1,
+      towerPowerPct: 100,
+    },
+    winnerTeamId: 2,
+    gameTimeMsec: 1000,
+    players,
+  } as GameEndDto;
+}
+
+describe('AnalyticsService.gameEndPlayerBot', () => {
+  it('sends awaken as 1 when player.awaken is 1', async () => {
+    const service = new AnalyticsService(null);
+    const sendEventSpy = jest.spyOn(service, 'sendEvent').mockResolvedValue(true);
+
+    const gameEnd = buildGameEnd([buildPlayer({ awaken: 1 })]);
+    await service.gameEndPlayerBot(gameEnd, SERVER_TYPE.TEST);
+
+    expect(sendEventSpy).toHaveBeenCalledTimes(1);
+    const event = sendEventSpy.mock.calls[0][1] as unknown as { params: { awaken: number } };
+    expect(event.params.awaken).toBe(1);
+  });
+
+  it('defaults awaken to 0 when player.awaken is not provided', async () => {
+    const service = new AnalyticsService(null);
+    const sendEventSpy = jest.spyOn(service, 'sendEvent').mockResolvedValue(true);
+
+    const gameEnd = buildGameEnd([buildPlayer()]);
+    await service.gameEndPlayerBot(gameEnd, SERVER_TYPE.TEST);
+
+    expect(sendEventSpy).toHaveBeenCalledTimes(1);
+    const event = sendEventSpy.mock.calls[0][1] as unknown as { params: { awaken: number } };
+    expect(event.params.awaken).toBe(0);
+  });
+});

--- a/api/src/analytics/analytics.service.ts
+++ b/api/src/analytics/analytics.service.ts
@@ -104,6 +104,7 @@ export class AnalyticsService {
           is_disconnect: player.isDisconnected,
           server_type: serverType,
           country: gameEnd.countryCode,
+          awaken: player.awaken ?? 0,
         });
 
         const userProperties: UserProperties = {};

--- a/api/src/analytics/dto/game-end-dto.ts
+++ b/api/src/analytics/dto/game-end-dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsArray, IsNotEmpty, IsNumber, Min, ValidateNested } from 'class-validator';
+import { IsArray, IsNotEmpty, IsNumber, IsOptional, Min, ValidateNested } from 'class-validator';
 
 import { EventBaseDto } from './event-base-dto';
 
@@ -72,6 +72,13 @@ export class GameEndPlayerDto {
   @IsNumber({ allowNaN: false, allowInfinity: false })
   @Min(0)
   towerKills: number;
+
+  /** 0 = 未觉醒，1 = 已觉醒；预留扩展，不可断言只有 0/1。旧客户端不发送时按 0 统计 */
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  awaken?: number;
 }
 
 export class GameEndDto extends EventBaseDto {


### PR DESCRIPTION
## Summary
- `GameEndPlayerDto` 新增可选字段 `awaken?: number`（`@IsOptional() @IsNumber() @Min(0)`），保持为数值类型（不转 boolean）以支持未来多阶觉醒扩展
- `AnalyticsService.gameEndPlayerBot()` 的 event params 增加 `awaken: player.awaken ?? 0`，`game_end_player` 与 `game_end_bot` 共用同一构建逻辑
- `game_end_match` 的 `buildPlayerJson()` 按 issue 要求暂不加该字段

Closes #1014

## Test plan
- [x] `npm run test`（unit，含新增 `analytics.service.spec.ts` 覆盖 `awaken=1` 与未传字段默认 0 两种场景）
- [x] `npm run lint`
- [x] `npm run test:e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)