### PR TITLE
Boost member point purchase tiers (price unchanged)

### DIFF
--- a/api/src/afdian/afdian.service.ts
+++ b/api/src/afdian/afdian.service.ts
@@ -30,9 +30,9 @@ enum PlanId {
 }
 
 enum PlanPoint {
-  tire1 = 3500,
-  tire2 = 11000,
-  tire3 = 28000,
+  tire1 = 4000,
+  tire2 = 12500,
+  tire3 = 31000,
 }
 
 @Injectable()

--- a/api/src/alipay/alipay.constants.ts
+++ b/api/src/alipay/alipay.constants.ts
@@ -38,19 +38,19 @@ export const ALIPAY_PRODUCT_TABLE: Record<AlipayProductCode, AlipayProductSpec> 
     reward: { kind: 'member', level: MemberLevel.PREMIUM },
   },
   [AlipayProductCode.POINTS_TIER1]: {
-    subjectUnit: '10v10AI 会员积分 3500',
+    subjectUnit: '10v10AI 会员积分 4000',
     priceCentPerUnit: 7800,
-    reward: { kind: 'points', points: 3500 },
+    reward: { kind: 'points', points: 4000 },
   },
   [AlipayProductCode.POINTS_TIER2]: {
-    subjectUnit: '10v10AI 会员积分 11000',
+    subjectUnit: '10v10AI 会员积分 12500',
     priceCentPerUnit: 23800,
-    reward: { kind: 'points', points: 11000 },
+    reward: { kind: 'points', points: 12500 },
   },
   [AlipayProductCode.POINTS_TIER3]: {
-    subjectUnit: '10v10AI 会员积分 28000',
+    subjectUnit: '10v10AI 会员积分 31000',
     priceCentPerUnit: 56800,
-    reward: { kind: 'points', points: 28000 },
+    reward: { kind: 'points', points: 31000 },
   },
 };
 

--- a/api/src/alipay/alipay.service.spec.ts
+++ b/api/src/alipay/alipay.service.spec.ts
@@ -395,15 +395,15 @@ describe('AlipayService', () => {
       await service.handleWebhook(buildNotify({ total_amount: '156.00' }));
 
       expect(playerService.upsertAddPoint).toHaveBeenCalledWith(123, {
-        memberPointTotal: 7000, // 3500 * 2
+        memberPointTotal: 8000, // 4000 * 2
       });
       expect(membersService.createMember).not.toHaveBeenCalled();
     });
 
     it.each([
-      [AlipayProductCode.POINTS_TIER1, 1, 7800, '78.00', 3500],
-      [AlipayProductCode.POINTS_TIER2, 1, 23800, '238.00', 11000],
-      [AlipayProductCode.POINTS_TIER3, 1, 56800, '568.00', 28000],
+      [AlipayProductCode.POINTS_TIER1, 1, 7800, '78.00', 4000],
+      [AlipayProductCode.POINTS_TIER2, 1, 23800, '238.00', 12500],
+      [AlipayProductCode.POINTS_TIER3, 1, 56800, '568.00', 31000],
     ])(
       '积分档位 %s 单份发放正确积分',
       async (code, quantity, totalAmountCent, amountStr, points) => {

--- a/api/src/kofi/kofi.service.ts
+++ b/api/src/kofi/kofi.service.ts
@@ -22,15 +22,15 @@ interface ShopItem {
 const SHOP_ITEMS: Record<string, ShopItem> = {
   TIER1: {
     code: '74a1b5be84',
-    points: 3500,
+    points: 4000,
   },
   TIER2: {
     code: '0e9591aa5d',
-    points: 11000,
+    points: 12500,
   },
   TIER3: {
     code: '3d4304d9a7',
-    points: 28000,
+    points: 31000,
   },
 };
 

--- a/api/test/afdian.e2e-spec.ts
+++ b/api/test/afdian.e2e-spec.ts
@@ -337,7 +337,7 @@ describe('MemberController (e2e)', () => {
             createWebhookRequest({
               out_trade_no: '202106232138371083454010623',
               user_id: 'adf397fe8374811eaacee52540025c377',
-              plan_id: '6f73a48e546011eda08052540025c377', // tire1 3500
+              plan_id: '6f73a48e546011eda08052540025c377', // tire1 4000
               month: month,
               remark: `${memberId}`,
               product_type: 1,
@@ -355,7 +355,7 @@ describe('MemberController (e2e)', () => {
         expect(responseCreate.body).toEqual({ ec: 200, em: 'ok' });
         // 检查玩家积分
         const player = await getPlayer(app, memberId);
-        expect(player.memberPointTotal).toEqual(3500);
+        expect(player.memberPointTotal).toEqual(4000);
       });
 
       it('爱发电Webhook购买会员积分 单次多个', async () => {
@@ -369,7 +369,7 @@ describe('MemberController (e2e)', () => {
             createWebhookRequest({
               out_trade_no: '202106232138371083454010624',
               user_id: 'adf397fe8374811eaacee52540025c377',
-              plan_id: '0783fa70688a11edacd452540025c377', // tire3 28000
+              plan_id: '0783fa70688a11edacd452540025c377', // tire3 31000
               month: month,
               remark: `${memberId}`,
               product_type: 1,
@@ -387,7 +387,7 @@ describe('MemberController (e2e)', () => {
         expect(responseCreate.body).toEqual({ ec: 200, em: 'ok' });
         // 检查玩家积分
         const player = await getPlayer(app, memberId);
-        expect(player.memberPointTotal).toEqual(56000);
+        expect(player.memberPointTotal).toEqual(62000);
       });
 
       it('爱发电Webhook购买会员积分 多次', async () => {
@@ -401,7 +401,7 @@ describe('MemberController (e2e)', () => {
             createWebhookRequest({
               out_trade_no: '202106232138371083454010625',
               user_id: 'adf397fe8374811eaacee52540025c377',
-              plan_id: '6f73a48e546011eda08052540025c377', // tire1 3500
+              plan_id: '6f73a48e546011eda08052540025c377', // tire1 4000
               month: month,
               remark: `${memberId}`,
               product_type: 1,
@@ -423,7 +423,7 @@ describe('MemberController (e2e)', () => {
             createWebhookRequest({
               out_trade_no: '202106232138371083454010626',
               user_id: 'adf397fe8374811eaacee52540025c377',
-              plan_id: '29df1632688911ed9e7052540025c377', // tire2 11000
+              plan_id: '29df1632688911ed9e7052540025c377', // tire2 12500
               month: month,
               remark: `${memberId}`,
               product_type: 1,
@@ -441,7 +441,7 @@ describe('MemberController (e2e)', () => {
         expect(responseCreate2.body).toEqual({ ec: 200, em: 'ok' });
         // 检查玩家积分
         const player = await getPlayer(app, memberId);
-        expect(player.memberPointTotal).toEqual(14500);
+        expect(player.memberPointTotal).toEqual(16500);
       });
     });
   });

--- a/api/test/alipay.e2e-spec.ts
+++ b/api/test/alipay.e2e-spec.ts
@@ -214,7 +214,7 @@ describe('AlipayController (e2e)', () => {
       expect(player.memberPointTotal).toBe(3000); // 1000 * 3 个月
     });
 
-    it('POINTS_TIER1 quantity=2：积分 +7000（无 member 记录）', async () => {
+    it('POINTS_TIER1 quantity=2：积分 +8000（无 member 记录）', async () => {
       const steamId = STEAM_IDS.WEBHOOK_POINTS_QTY2;
       const order = await createOrder({
         steamId,
@@ -229,7 +229,7 @@ describe('AlipayController (e2e)', () => {
 
       expect(res.text).toBe('success');
       const player = await getPlayer(app, steamId);
-      expect(player.memberPointTotal).toBe(7000);
+      expect(player.memberPointTotal).toBe(8000);
 
       // 积分订单不应创建 member 记录
       await expect(getMemberDto(app, steamId)).rejects.toThrow();

--- a/api/test/alipay.e2e-spec.ts
+++ b/api/test/alipay.e2e-spec.ts
@@ -331,7 +331,7 @@ describe('AlipayController (e2e)', () => {
       );
       expect(r1.text).toBe('success');
       const afterFirst = (await getPlayer(app, steamId)).memberPointTotal;
-      expect(afterFirst - beforePoints).toBe(3500);
+      expect(afterFirst - beforePoints).toBe(4000);
 
       const r2 = await postWebhook(
         buildNotify({ out_trade_no: outTradeNo, total_amount: '78.00' }),

--- a/api/test/kofi.e2e-spec.ts
+++ b/api/test/kofi.e2e-spec.ts
@@ -749,7 +749,7 @@ describe('KofiController (e2e)', () => {
     describe('Ko-fi Webhook购买商品', () => {
       it.each([
         [
-          '单个商品 Tier1 3500积分',
+          '单个商品 Tier1 4000积分',
           200010101,
           'single-item-t1@example.com',
           [
@@ -759,10 +759,10 @@ describe('KofiController (e2e)', () => {
               variation_name: null,
             },
           ],
-          3500,
+          4000,
         ],
         [
-          '单个商品 Tier2 11000积分',
+          '单个商品 Tier2 12500积分',
           200010102,
           'single-item-t2@example.com',
           [
@@ -772,10 +772,10 @@ describe('KofiController (e2e)', () => {
               variation_name: null,
             },
           ],
-          11000,
+          12500,
         ],
         [
-          '单个商品 Tier3 28000积分',
+          '单个商品 Tier3 31000积分',
           200010103,
           'single-item-t3@example.com',
           [
@@ -785,7 +785,7 @@ describe('KofiController (e2e)', () => {
               variation_name: null,
             },
           ],
-          28000,
+          31000,
         ],
         [
           '一个商品多件',
@@ -798,7 +798,7 @@ describe('KofiController (e2e)', () => {
               variation_name: null,
             },
           ],
-          22000,
+          25000,
         ],
         [
           '多种商品多件',
@@ -816,7 +816,7 @@ describe('KofiController (e2e)', () => {
               variation_name: null,
             },
           ],
-          35000,
+          39000,
         ],
       ])('%s', async (_, memberId, email, shopItems, expectedPoints) => {
         // 创建玩家


### PR DESCRIPTION
## Summary
- Configure with #1016 (会员积分觉醒下调至 4000 / 随机 2000): 最低档 3500 买不了一次指定觉醒，三档同时加量，价格全部不变
- `api/src/alipay/alipay.constants.ts`：TIER1 3500→4000，TIER2 11000→12500，TIER3 28000→31000（`reward.points` 与 `subjectUnit` 文案）
- 同步调整爱发电（`api/src/afdian/afdian.service.ts` `PlanPoint`）与 Ko-fi（`api/src/kofi/kofi.service.ts` `SHOP_ITEMS`）的积分数值
- 同步更新 `alipay.service.spec.ts`、`alipay.e2e-spec.ts`、`afdian.e2e-spec.ts`、`kofi.e2e-spec.ts` 中的积分期望值

## Related (not in this PR)
- game 侧前端档位常量随 windy10v10ai/game#2282 一起改
- 爱发电与 Ko-fi 的商品页描述需在各自平台后台手动改积分数量（价格不变）
- 发布顺序：后端先于 game 发布，发布后确认三个平台的到账积分与商品描述一致

Closes #1017

## Test plan
- [x] `cd api && npm run lint`
- [x] `cd api && npm run test`（169 passed）
- [x] `cd api && npm run test:e2e` — 跳过，本地 8080 端口被用户正在运行的 dev 环境占用，未与用户协商停用；改动仅为常量数值同步，unit test 已覆盖对应逻辑分支