### PR TITLE
Add awaken event reward: 2000 member points on login (8/2-8/9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ gcloud config set project windy10v10ai
 # download data from storage
 rm -rf firestore-backup
 mkdir firestore-backup
-gsutil -m cp -r "gs://windy10v10ai.appspot.com/firestore-backup/20260629/*" firestore-backup
+gsutil -m cp -r "gs://windy10v10ai.appspot.com/firestore-backup/20260802/*" firestore-backup
 ```
 
 ### Start Firebase Emulator & API & Web

--- a/api/src/event-rewards/entities/event-reward.entity.ts
+++ b/api/src/event-rewards/entities/event-reward.entity.ts
@@ -28,4 +28,5 @@ export class EventReward {
   mayDay2026?: boolean; // 51活动：5100会员积分
   dragonBoat2026?: boolean;
   aoeBonusProperty2026?: boolean; // 新属性 AOE Bonus 上线奖励：5000勇士积分
+  awaken20260802?: boolean; // 觉醒活动奖励（8/2-8/9，登录发放）：2000会员积分
 }

--- a/api/src/event-rewards/event-rewards.service.ts
+++ b/api/src/event-rewards/event-rewards.service.ts
@@ -35,12 +35,12 @@ export class EventRewardsService {
         id,
         steamId,
         // FIXME 活动每次需要更新
-        aoeBonusProperty2026: true,
+        awaken20260802: true,
       });
     } else {
       // update
       // FIXME 活动每次需要更新
-      eventReward.aoeBonusProperty2026 = true;
+      eventReward.awaken20260802 = true;
       await this.eventRewardsRepository.update(eventReward);
     }
   }

--- a/api/src/game/game.service.spec.ts
+++ b/api/src/game/game.service.spec.ts
@@ -151,30 +151,30 @@ describe('GameService', () => {
       jest.clearAllMocks();
     });
 
-    it('windy主机 活动期间内 未领取 应发放新属性作用范围活动积分', async () => {
-      jest.useFakeTimers().setSystemTime(new Date('2026-07-27T00:00:00.000Z'));
+    it('windy主机 活动期间内 未领取 应发放觉醒活动积分', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-08-03T00:00:00.000Z'));
       eventRewardsService.getRewardResults.mockResolvedValue([{ steamId, result: undefined }]);
 
       const result = await service.giveEventReward([steamId], SERVER_TYPE.WINDY);
 
       expect(playerService.upsertAddPoint).toHaveBeenCalledWith(steamId, {
-        seasonPointTotal: 5000,
+        memberPointTotal: 2000,
       });
       expect(eventRewardsService.setReward).toHaveBeenCalledWith(steamId);
       expect(result).toEqual([
         {
           steamId,
           title: {
-            cn: '新属性作用范围',
-            en: 'New Property: AOE Bonus',
+            cn: '觉醒活动奖励',
+            en: 'Awaken Event Reward',
           },
-          seasonPoint: 5000,
+          memberPoint: 2000,
         },
       ]);
     });
 
     it('非windy主机 活动期间内 不应发放', async () => {
-      jest.useFakeTimers().setSystemTime(new Date('2026-07-27T00:00:00.000Z'));
+      jest.useFakeTimers().setSystemTime(new Date('2026-08-03T00:00:00.000Z'));
 
       const result = await service.giveEventReward([steamId], SERVER_TYPE.TEST);
 
@@ -184,7 +184,7 @@ describe('GameService', () => {
     });
 
     it('windy主机 活动期间外 不应发放', async () => {
-      jest.useFakeTimers().setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+      jest.useFakeTimers().setSystemTime(new Date('2026-08-10T00:00:00.000Z'));
       eventRewardsService.getRewardResults.mockResolvedValue([{ steamId, result: undefined }]);
 
       const result = await service.giveEventReward([steamId], SERVER_TYPE.WINDY);
@@ -194,9 +194,9 @@ describe('GameService', () => {
     });
 
     it('windy主机 活动期间内 已领取 不应重复发放', async () => {
-      jest.useFakeTimers().setSystemTime(new Date('2026-07-27T00:00:00.000Z'));
+      jest.useFakeTimers().setSystemTime(new Date('2026-08-03T00:00:00.000Z'));
       eventRewardsService.getRewardResults.mockResolvedValue([
-        { steamId, result: { id: steamId.toString(), steamId, aoeBonusProperty2026: true } },
+        { steamId, result: { id: steamId.toString(), steamId, awaken20260802: true } },
       ]);
 
       const result = await service.giveEventReward([steamId], SERVER_TYPE.WINDY);

--- a/api/src/game/game.service.ts
+++ b/api/src/game/game.service.ts
@@ -68,9 +68,9 @@ export class GameService {
     const pointInfoDtos: PointInfoDto[] = [];
 
     // FIXME 活动每次需要更新
-    const startTime = new Date('2026-07-26T00:00:00.000Z');
-    const endTime = new Date('2026-07-31T23:59:59.999Z');
-    const seasonRewardPoint = 5000;
+    const startTime = new Date('2026-08-02T00:00:00.000Z');
+    const endTime = new Date('2026-08-09T23:59:59.999Z');
+    const memberRewardPoint = 2000;
 
     const now = new Date();
 
@@ -84,18 +84,18 @@ export class GameService {
 
     for (const rewardResult of rewardResults) {
       // FIXME 活动每次需要更新
-      if (now >= startTime && now <= endTime && !rewardResult.result?.aoeBonusProperty2026) {
+      if (now >= startTime && now <= endTime && !rewardResult.result?.awaken20260802) {
         await this.playerService.upsertAddPoint(rewardResult.steamId, {
-          seasonPointTotal: seasonRewardPoint,
+          memberPointTotal: memberRewardPoint,
         });
         await this.eventRewardsService.setReward(rewardResult.steamId);
         pointInfoDtos.push({
           steamId: rewardResult.steamId,
           title: {
-            cn: '新属性作用范围',
-            en: 'New Property: AOE Bonus',
+            cn: '觉醒活动奖励',
+            en: 'Awaken Event Reward',
           },
-          seasonPoint: seasonRewardPoint,
+          memberPoint: memberRewardPoint,
         });
       }
     }

--- a/api/test/game.e2e-spec.ts
+++ b/api/test/game.e2e-spec.ts
@@ -508,8 +508,8 @@ describe('PlayerController (e2e)', () => {
     describe('事件奖励', () => {
       it('windy主机 活动期间内首次登录 获得活动积分', async () => {
         const steamId = 100000901;
-        // 活动期间: 2026-07-26 ~ 2026-07-31
-        mockDate('2026-07-27T00:00:00.000Z');
+        // 活动期间: 2026-08-02 ~ 2026-08-09
+        mockDate('2026-08-03T00:00:00.000Z');
 
         const result = await callGameStartAsWindyHost(app, [steamId]);
         expect(result.status).toEqual(200);
@@ -518,26 +518,26 @@ describe('PlayerController (e2e)', () => {
         const pointInfo = result.body.pointInfo;
         const eventReward = pointInfo.find(
           (p: { steamId: number; seasonPoint?: number; memberPoint?: number }) =>
-            p.steamId === steamId && p.seasonPoint,
+            p.steamId === steamId && p.memberPoint,
         );
         expect(eventReward).toBeDefined();
-        expect(eventReward.seasonPoint).toEqual(5000);
+        expect(eventReward.memberPoint).toEqual(2000);
 
         // 验证玩家积分
         const player = await getPlayer(app, steamId);
-        expect(player.seasonPointTotal).toEqual(5000);
-        expect(player.memberPointTotal).toEqual(0);
+        expect(player.memberPointTotal).toEqual(2000);
+        expect(player.seasonPointTotal).toEqual(0);
       });
 
       it('windy主机 活动期间内第二次登录 不重复获得积分', async () => {
         const steamId = 100000902;
-        mockDate('2026-07-27T00:00:00.000Z');
+        mockDate('2026-08-03T00:00:00.000Z');
 
         // 第一次登录
         await callGameStartAsWindyHost(app, [steamId]);
         const player1 = await getPlayer(app, steamId);
-        expect(player1.seasonPointTotal).toEqual(5000);
-        expect(player1.memberPointTotal).toEqual(0);
+        expect(player1.memberPointTotal).toEqual(2000);
+        expect(player1.seasonPointTotal).toEqual(0);
 
         // 第二次登录
         const result = await callGameStartAsWindyHost(app, [steamId]);
@@ -547,20 +547,20 @@ describe('PlayerController (e2e)', () => {
         const pointInfo = result.body.pointInfo;
         const eventReward = pointInfo.find(
           (p: { steamId: number; seasonPoint?: number; memberPoint?: number }) =>
-            p.steamId === steamId && p.seasonPoint,
+            p.steamId === steamId && p.memberPoint,
         );
         expect(eventReward).toBeUndefined();
 
         // 积分不变
         const player2 = await getPlayer(app, steamId);
-        expect(player2.seasonPointTotal).toEqual(5000);
-        expect(player2.memberPointTotal).toEqual(0);
+        expect(player2.memberPointTotal).toEqual(2000);
+        expect(player2.seasonPointTotal).toEqual(0);
       });
 
       it('windy主机 活动期间外 不获得活动积分', async () => {
         const steamId = 100000903;
         // 活动期间外
-        mockDate('2026-08-01T00:00:00.000Z');
+        mockDate('2026-08-10T00:00:00.000Z');
 
         const result = await callGameStartAsWindyHost(app, [steamId]);
         expect(result.status).toEqual(200);
@@ -569,7 +569,7 @@ describe('PlayerController (e2e)', () => {
         const pointInfo = result.body.pointInfo;
         const eventReward = pointInfo.find(
           (p: { steamId: number; seasonPoint?: number; memberPoint?: number }) =>
-            p.steamId === steamId && p.seasonPoint,
+            p.steamId === steamId && p.memberPoint,
         );
         expect(eventReward).toBeUndefined();
 
@@ -582,7 +582,7 @@ describe('PlayerController (e2e)', () => {
       it('非windy主机 活动期间内 不获得活动积分', async () => {
         const steamId = 100000904;
         // 活动期间内
-        mockDate('2026-07-27T00:00:00.000Z');
+        mockDate('2026-08-03T00:00:00.000Z');
 
         const result = await callGameStart(app, [steamId]);
         expect(result.status).toEqual(200);
@@ -591,7 +591,7 @@ describe('PlayerController (e2e)', () => {
         const pointInfo = result.body.pointInfo;
         const eventReward = pointInfo.find(
           (p: { steamId: number; seasonPoint?: number; memberPoint?: number }) =>
-            p.steamId === steamId && p.seasonPoint,
+            p.steamId === steamId && p.memberPoint,
         );
         expect(eventReward).toBeUndefined();
 


### PR DESCRIPTION
## Summary
- 新增觉醒活动奖励：8/2 00:00 UTC ~ 8/9 23:59:59 UTC 期间，windy 主机玩家登录（game/start）一次性发放 2000 会员积分
- 复用现有 `EventReward` 一次性活动标记模式（沿用此前 AOE Bonus 活动同一套机制），新增标记字段 `awaken20260802`
- 顺带把 README 里 firestore-backup 的快照日期更新到最新导出（20260802）

## Test plan
- [x] `cd api && npm run lint`
- [x] `cd api && npx tsc --noEmit`
- [x] `cd api && npm run test`（169 passed，含更新后的 `game.service.spec.ts` 5 个用例）
- [x] `cd api && npm run test:e2e` — 跳过，本地 8080 端口被开发者本地 dev 环境占用